### PR TITLE
Settings Driven LLM Toolbox for customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Split the searchable embeddings of image descriptions into 800 string length chunks for better search results, which also allows more image responses.
 - There is a welcome page now when the system starts first without settings - choose between import or manual configuration.
 - Added a button for markdown editor to toggle fullscreen mode.
+- Implemented that descriptions for chatbot functions are editable within the settings.
 
 ### Changed
 - Raised default library responses to ChatGPT to 20 documents and 15 images within the default settings.

--- a/src/Settings/Domain/ValueObject/Settings/ChatbotFunctions.php
+++ b/src/Settings/Domain/ValueObject/Settings/ChatbotFunctions.php
@@ -6,13 +6,16 @@ namespace ChronicleKeeper\Settings\Domain\ValueObject\Settings;
 
 /**
  * @phpstan-type ChatbotFunctionsArray = array{
- *     allow_debug_output: bool
+ *     allow_debug_output: bool,
+ *     function_descriptions?: array<string, string>
  * }
  */
 class ChatbotFunctions
 {
+    /** @param array<string, string> $functionDescriptions */
     public function __construct(
         private readonly bool $allowDebugOutput = false,
+        private readonly array $functionDescriptions = [],
     ) {
     }
 
@@ -21,6 +24,7 @@ class ChatbotFunctions
     {
         return new ChatbotFunctions(
             $array['allow_debug_output'],
+            $array['function_descriptions'] ?? [],
         );
     }
 
@@ -29,11 +33,18 @@ class ChatbotFunctions
     {
         return [
             'allow_debug_output' => $this->allowDebugOutput,
+            'function_descriptions' => $this->functionDescriptions,
         ];
     }
 
     public function isAllowDebugOutput(): bool
     {
         return $this->allowDebugOutput;
+    }
+
+    /** @return array<string, string> */
+    public function getFunctionDescriptions(): array
+    {
+        return $this->functionDescriptions;
     }
 }

--- a/src/Settings/Presentation/Controller/ChangeSettings.php
+++ b/src/Settings/Presentation/Controller/ChangeSettings.php
@@ -9,7 +9,6 @@ use ChronicleKeeper\Settings\Presentation\Form\ApplicationType;
 use ChronicleKeeper\Settings\Presentation\Form\CalendarGeneralType;
 use ChronicleKeeper\Settings\Presentation\Form\CalendarHolidayType;
 use ChronicleKeeper\Settings\Presentation\Form\CalendarMoonType;
-use ChronicleKeeper\Settings\Presentation\Form\ChatbotFunctionsType;
 use ChronicleKeeper\Settings\Presentation\Form\ChatbotGeneralType;
 use ChronicleKeeper\Settings\Presentation\Form\ChatbotSystemPromptType;
 use ChronicleKeeper\Settings\Presentation\Form\ChatbotTuningType;
@@ -27,7 +26,7 @@ use Twig\Environment;
 
 use function is_string;
 
-#[Route('/settings/{section}', name: 'settings', defaults: ['section' => 'chatbot_general'])]
+#[Route('/settings/{section}', name: 'settings', defaults: ['section' => 'chatbot_general'], priority: 0)]
 class ChangeSettings extends AbstractController
 {
     use HandleFlashMessages;
@@ -37,7 +36,6 @@ class ChangeSettings extends AbstractController
         'chatbot_general' => ChatbotGeneralType::class,
         'chatbot_system_prompt' => ChatbotSystemPromptType::class,
         'chatbot_tuning' => ChatbotTuningType::class,
-        'chatbot_functions' => ChatbotFunctionsType::class,
         'calendar_general' => CalendarGeneralType::class,
         'calendar_holiday' => CalendarHolidayType::class,
         'calendar_moon' => CalendarMoonType::class,

--- a/src/Settings/Presentation/Controller/ChangeSettings/ChangeChatbotFunctions.php
+++ b/src/Settings/Presentation/Controller/ChangeSettings/ChangeChatbotFunctions.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Settings\Presentation\Controller\ChangeSettings;
+
+use ChronicleKeeper\Settings\Application\SettingsHandler;
+use ChronicleKeeper\Settings\Presentation\Form\ChatbotFunctionsType;
+use ChronicleKeeper\Shared\Infrastructure\LLMChain\ToolboxFactory;
+use ChronicleKeeper\Shared\Presentation\FlashMessages\Alert;
+use ChronicleKeeper\Shared\Presentation\FlashMessages\HandleFlashMessages;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/settings/chatbot_functions', name: 'settings_chatbot_functions', priority: 10)]
+class ChangeChatbotFunctions extends AbstractController
+{
+    use HandleFlashMessages;
+
+    public function __construct(
+        private readonly SettingsHandler $settingsHandler,
+        private readonly ToolboxFactory $toolboxFactory,
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $settings = $this->settingsHandler->get();
+
+        $form = $this->createForm(ChatbotFunctionsType::class, $settings);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->settingsHandler->store();
+
+            $this->addFlashMessage($request, Alert::SUCCESS, 'Die Einstellungen wurden gespeichert.');
+
+            return $this->redirectToRoute('settings_chatbot_functions');
+        }
+
+        return $this->render(
+            'settings/chatbot_functions.html.twig',
+            [
+                'form' => $form->createView(),
+                'tools' => $this->toolboxFactory->create(),
+            ],
+        );
+    }
+}

--- a/src/Shared/Infrastructure/LLMChain/SettingsToolBox.php
+++ b/src/Shared/Infrastructure/LLMChain/SettingsToolBox.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Shared\Infrastructure\LLMChain;
+
+use ChronicleKeeper\Settings\Application\SettingsHandler;
+use PhpLlm\LlmChain\Response\ToolCall;
+use PhpLlm\LlmChain\ToolBox\Metadata;
+use PhpLlm\LlmChain\ToolBox\ToolBox;
+use PhpLlm\LlmChain\ToolBox\ToolBoxInterface;
+
+class SettingsToolBox implements ToolBoxInterface
+{
+    public function __construct(
+        private readonly SettingsHandler $settingsHandler,
+        private readonly ToolBox $llmToolBox,
+    ) {
+    }
+
+    /** @return Metadata[] */
+    public function getMap(): array
+    {
+        $toolMap = $this->llmToolBox->getMap();
+
+        // Check Settings for custom tool names and descriptions and overhault the metadata here :)
+
+        return $toolMap;
+    }
+
+    /**
+     * There is no need for customization here as the purpose of this wrapper is to have the
+     * possibility of changing the names and descriptions parsed from the class attributes if
+     * there are custom settings of the application are available.
+     */
+    public function execute(ToolCall $toolCall): string
+    {
+        return $this->llmToolBox->execute($toolCall);
+    }
+}

--- a/src/Shared/Infrastructure/LLMChain/ToolboxFactory.php
+++ b/src/Shared/Infrastructure/LLMChain/ToolboxFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ChronicleKeeper\Shared\Infrastructure\LLMChain;
 
+use ChronicleKeeper\Settings\Application\SettingsHandler;
 use PhpLlm\LlmChain\ToolBox\ToolAnalyzer;
 use PhpLlm\LlmChain\ToolBox\ToolBox;
 use PhpLlm\LlmChain\ToolBox\ToolBoxInterface;
@@ -21,6 +22,7 @@ class ToolboxFactory
 
     /** @param object[] $tools */
     public function __construct(
+        private readonly SettingsHandler $settingsHandler,
         #[AutowireIterator('llm_chain.tool')]
         iterable $tools = [],
     ) {
@@ -29,6 +31,9 @@ class ToolboxFactory
 
     public function create(): ToolBoxInterface
     {
-        return new ToolBox(new ToolAnalyzer(), $this->tools);
+        return new SettingsToolBox(
+            $this->settingsHandler,
+            new ToolBox(new ToolAnalyzer(), $this->tools),
+        );
     }
 }

--- a/templates/settings/_includes/settings_nav.html.twig
+++ b/templates/settings/_includes/settings_nav.html.twig
@@ -5,7 +5,7 @@
             <a href="{{ path('settings') }}" class="list-group-item list-group-item-action d-flex align-items-center{{ form.vars.name is same as 'chatbot_general' ? ' active' : '' }}">Allgemein</a>
             <a href="{{ path('settings', {'section': 'chatbot_tuning'}) }}" class="list-group-item list-group-item-action{{ form.vars.name is same as 'chatbot_tuning' ? ' active' : '' }}">Tuning</a>
             <a href="{{ path('settings', {'section': 'chatbot_system_prompt'}) }}" class="list-group-item list-group-item-action{{ form.vars.name is same as 'chatbot_system_prompt' ? ' active' : '' }}">System Prompt</a>
-            <a href="{{ path('settings', {'section': 'chatbot_functions'}) }}" class="list-group-item list-group-item-action{{ form.vars.name is same as 'chatbot_functions' ? ' active' : '' }}">Funktionen</a>
+            <a href="{{ path('settings_chatbot_functions') }}" class="list-group-item list-group-item-action{{ app.request.attributes.get('_route') is same as 'settings_chatbot_functions' ? ' active' : '' }}">Funktionen</a>
         </div>
         <h4 class="subheader mt-4">Kalender</h4>
         <div class="list-group list-group-transparent">

--- a/templates/settings/chatbot_functions.html.twig
+++ b/templates/settings/chatbot_functions.html.twig
@@ -38,118 +38,27 @@
                             </div>
 
                             <div class="accordion" id="accordion-example">
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="heading-1">
-                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-1" aria-expanded="true">
-                                            library_documents
-                                        </button>
-                                    </h2>
-                                    <div id="collapse-1" class="accordion-collapse collapse show" data-bs-parent="#accordion-example" style="">
-                                        <div class="accordion-body pt-0">
-                                            Provides textual background information related to the role-playing game
-                                            world. This includes details on places, characters, religions, and other
-                                            elements existing within the game universe. For visual representations,
-                                            consider using the "library_images" function.
+                                {% for tool in tools.map %}
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header" id="heading-{{ loop.index }}">
+                                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ loop.index }}" aria-expanded="{{ loop.first ? 'true' : 'false' }}">
+                                                {{ tool.name }}
+                                            </button>
+                                        </h2>
+                                        <div id="collapse-{{ loop.index }}" class="accordion-collapse collapse {{ loop.first ? 'show' }}" data-bs-parent="#accordion-example" style="">
+                                            <div class="accordion-body pt-0">
+                                                <p class="strong text-decoration-underline">Beschreibung</p>
+                                                <p>{{ form_widget(attribute(form, tool.name), { 'attr': {'rows': 10} }) }}</p>
+                                                {% if tool.parameters is not empty and tool.parameters.properties is not empty %}
+                                                    <p class="strong text-decoration-underline">Argumente</p>
+                                                    {% for parameterName, parameter in tool.parameters.properties %}
+                                                        <p>{{ parameterName }}: {{ parameter.description }}</p>
+                                                    {% endfor %}
+                                                {% endif %}
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="heading-2">
-                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-2" aria-expanded="false">
-                                            library_images
-                                        </button>
-                                    </h2>
-                                    <div id="collapse-2" class="accordion-collapse collapse" data-bs-parent="#accordion-example" style="">
-                                        <div class="accordion-body pt-0">
-                                            Delivers images and pictures from the role-playing game world. For additional background information, consider using
-                                            the "library_documents" function. The images and pictures delivered here will help you describe locations,
-                                            situations, and characters from the game universe.
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="heading-3">
-                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-3" aria-expanded="false">
-                                            current_date
-                                        </button>
-                                    </h2>
-                                    <div id="collapse-3" class="accordion-collapse collapse" data-bs-parent="#accordion-example" style="">
-                                        <div class="accordion-body pt-0">
-                                            Provides the current date in the role-playing game world. Use this function to get the exact current date (day,
-                                            month, and year) as it is in the game universe. For understanding the structure of the calendar, such as the names
-                                            of the months, the number of days in each month, or detailed inquiries about the calendar, consider using the
-                                            "calendar" function. For understanding the phases of the moon or lunar-related events, use the "moon_calendar"
-                                            function. For information on holidays and observances, refer to "calendar_holiday". If additional details about the
-                                            calendar system, structure, or related events are requested, ensure to fetch these using the appropriate functions.<br />
-                                            <br />
-                                            Examples include:<br />
-                                            - Today's date: "What is the date today?"<br />
-                                            - Specific event timing: "What is the current date?"<br />
-                                            - Timeline alignment: "Where are we in the year?"<br />
-                                            <br />
-                                            Note: For questions about the broader calendar context, such as calculations with the calendar refer to the known
-                                            functionalities to fetch additional information.
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="heading-4">
-                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-4" aria-expanded="false">
-                                            calendar
-                                        </button>
-                                    </h2>
-                                    <div id="collapse-4" class="accordion-collapse collapse" data-bs-parent="#accordion-example" style="">
-                                        <div class="accordion-body pt-0">
-                                            Provides information about the calendar system in the role-playing game world. This includes details on the
-                                            structure of the year, month names, the number of days in different cycles, and other relevant calendar
-                                            information. Use this function for general calendar details and to understand the overall structure of the game's
-                                            timeline. For specific dates, refer to "current_date". For holiday-related dates, refer to "calendar_holiday".<br />
-                                            Examples include:<br />
-                                            - Understanding the structure of the year: "How many days are in a year?"<br />
-                                            - Detailing month names: "What are the names of the months?"<br />
-                                            - Number of days in cycles: "How many days are in a month?"<br />
-                                            - General calendar questions: "What is a typical year like?"
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="heading-5">
-                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-5" aria-expanded="false">
-                                            calendar_holiday
-                                        </button>
-                                    </h2>
-                                    <div id="collapse-5" class="accordion-collapse collapse" data-bs-parent="#accordion-example" style="">
-                                        <div class="accordion-body pt-0">
-                                            Provides information about holidays in the role-playing game world. Use this function to get details about specific
-                                            holidays and their dates. To understand how holidays fit into the broader calendar, refer to "calendar". For the
-                                            current date, use "current_date".<br />
-                                            Examples include:<br />
-                                            - Specific holiday details: "What holidays are celebrated this month?"<br />
-                                            - Understanding holiday observances: "What are the major holidays in this world?"<br />
-                                            - Aligning holidays in the calendar: "When is the next festival?"
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="heading-6">
-                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-6" aria-expanded="false">
-                                            moon_calendar
-                                        </button>
-                                    </h2>
-                                    <div id="collapse-6" class="accordion-collapse collapse" data-bs-parent="#accordion-example" style="">
-                                        <div class="accordion-body pt-0">
-                                            Provides information about the moon cycles and the entire lunar calendar in the role-playing game world. This is
-                                            useful for understanding phases of the moon, their effects, and related events. For explicit date-related
-                                            information, consider referencing the "calendar" and "calendar_holiday" functions. For the current date,
-                                            refer to "current_date".<br />
-                                            Examples include:<br />
-                                            - Current moon phase: "What phase is the moon in today?"<br />
-                                            - Detailed moon cycles: "What are the phases of the moon?"<br />
-                                            - Calendar alignment: "How does the lunar calendar align with the regular calendar?"<br />
-                                            - Specific moon-related events: "When is the next lunar eclipse?"<br />
-                                        </div>
-                                    </div>
-                                </div>
+                                {% endfor %}
                             </div>
 
                         </div>

--- a/tests/Shared/Infrastructure/LLMChain/SettingsToolBoxTest.php
+++ b/tests/Shared/Infrastructure/LLMChain/SettingsToolBoxTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Shared\Infrastructure\LLMChain;
+
+use ChronicleKeeper\Settings\Application\SettingsHandler;
+use ChronicleKeeper\Settings\Domain\ValueObject\Settings\ChatbotFunctions;
+use ChronicleKeeper\Shared\Infrastructure\LLMChain\SettingsToolBox;
+use ChronicleKeeper\Test\Settings\Domain\ValueObject\SettingsBuilder;
+use PhpLlm\LlmChain\Response\ToolCall;
+use PhpLlm\LlmChain\ToolBox\Metadata;
+use PhpLlm\LlmChain\ToolBox\ToolBoxInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SettingsToolBox::class)]
+#[Small]
+class SettingsToolBoxTest extends TestCase
+{
+    #[Test]
+    public function getMapWithoutTools(): void
+    {
+        $settingsHandler = self::createStub(SettingsHandler::class);
+        $llmToolBox      = self::createStub(ToolBoxInterface::class);
+        $settingsToolBox = new SettingsToolBox($settingsHandler, $llmToolBox);
+
+        self::assertEmpty($settingsToolBox->getMap());
+    }
+
+    #[Test]
+    public function getMapWithTools(): void
+    {
+        $exampleTool = new Metadata(
+            'ExampleTool',
+            'ExampleTool',
+            'This is an example tool.',
+            '__invoke',
+            null,
+        );
+
+        $settingsHandler = self::createStub(SettingsHandler::class);
+        $llmToolBox      = self::createStub(ToolBoxInterface::class);
+        $llmToolBox->method('getMap')->willReturn([$exampleTool]);
+        $settingsToolBox = new SettingsToolBox($settingsHandler, $llmToolBox);
+
+        self::assertCount(1, $settingsToolBox->getMap());
+    }
+
+    #[Test]
+    public function getMapWithToolsAndDescriptions(): void
+    {
+        $exampleTool = new Metadata(
+            'ExampleTool',
+            'ExampleTool',
+            'This is an example tool.',
+            '__invoke',
+            null,
+        );
+
+        $settings = (new SettingsBuilder())
+            ->withChatbotFunctions((new ChatbotFunctions(
+                false,
+                ['ExampleTool' => 'foo bar baz'],
+            )))
+            ->build();
+
+        $settingsHandler = self::createStub(SettingsHandler::class);
+        $settingsHandler->method('get')->willReturn($settings);
+
+        $llmToolBox = self::createStub(ToolBoxInterface::class);
+        $llmToolBox->method('getMap')->willReturn([$exampleTool]);
+        $settingsToolBox = new SettingsToolBox($settingsHandler, $llmToolBox);
+
+        $metadata = $settingsToolBox->getMap()[0];
+        self::assertSame('foo bar baz', $metadata->description);
+    }
+
+    #[Test]
+    public function execute(): void
+    {
+        $toolCall = new ToolCall('ExampleTool', '__invoke', ['foo' => 'foo bar baz']);
+
+        $llmToolBox = $this->createMock(ToolBoxInterface::class);
+        $llmToolBox->expects($this->once())->method('execute')->with($toolCall)->willReturn('foo bar baz');
+
+        $settingsToolBox = new SettingsToolBox(self::createStub(SettingsHandler::class), $llmToolBox);
+
+        self::assertSame('foo bar baz', $settingsToolBox->execute($toolCall));
+    }
+}

--- a/tests/Shared/Infrastructure/LLMChain/Stub/ExampleTool.php
+++ b/tests/Shared/Infrastructure/LLMChain/Stub/ExampleTool.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Shared\Infrastructure\LLMChain\Stub;
+
+use PhpLlm\LlmChain\ToolBox\Attribute\AsTool;
+
+#[AsTool('ExampleTool', 'This is an example tool.')]
+class ExampleTool
+{
+    /** @param string $foo This is an example description. */
+    public function __invoke(string $foo): string
+    {
+        return $foo;
+    }
+}

--- a/tests/Shared/Infrastructure/LLMChain/ToolboxFactoryTest.php
+++ b/tests/Shared/Infrastructure/LLMChain/ToolboxFactoryTest.php
@@ -5,67 +5,48 @@ declare(strict_types=1);
 namespace ChronicleKeeper\Test\Shared\Infrastructure\LLMChain;
 
 use ArrayIterator;
+use ChronicleKeeper\Settings\Application\SettingsHandler;
+use ChronicleKeeper\Shared\Infrastructure\LLMChain\SettingsToolBox;
 use ChronicleKeeper\Shared\Infrastructure\LLMChain\ToolboxFactory;
+use ChronicleKeeper\Test\Shared\Infrastructure\LLMChain\Stub\ExampleTool;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 
 #[CoversClass(ToolboxFactory::class)]
+#[UsesClass(SettingsToolBox::class)]
 #[Small]
 class ToolboxFactoryTest extends TestCase
 {
     #[Test]
     public function createWithoutTools(): void
     {
-        $toolboxFactory = new ToolboxFactory();
+        $toolboxFactory = new ToolboxFactory(self::createStub(SettingsHandler::class));
         $toolbox        = $toolboxFactory->create();
 
-        $reflection = new ReflectionClass($toolbox);
-        $property   = $reflection->getProperty('tools');
-        $tools      = $property->getValue($toolbox);
-
-        self::assertEmpty($tools);
+        self::assertEmpty($toolbox->getMap());
     }
 
     #[Test]
     public function createWithTools(): void
     {
-        $tool1 = new class {
-        };
-        $tool2 = new class {
-        };
-
-        $toolboxFactory = new ToolboxFactory([$tool1, $tool2]);
+        $toolboxFactory = new ToolboxFactory(self::createStub(SettingsHandler::class), [new ExampleTool()]);
         $toolbox        = $toolboxFactory->create();
 
-        $reflection = new ReflectionClass($toolbox);
-        $property   = $reflection->getProperty('tools');
-        $tools      = $property->getValue($toolbox);
-
-        self::assertCount(2, $tools);
-        self::assertSame($tool1, $tools[0]);
-        self::assertSame($tool2, $tools[1]);
+        self::assertCount(1, $toolbox->getMap());
     }
 
     #[Test]
     public function createWithToolsFromIterator(): void
     {
-        $tool1 = new class {
-        };
-        $tool2 = new class {
-        };
-
-        $toolboxFactory = new ToolboxFactory(new ArrayIterator([$tool1, $tool2]));
+        $toolboxFactory = new ToolboxFactory(
+            self::createStub(SettingsHandler::class),
+            new ArrayIterator([new ExampleTool()]),
+        );
         $toolbox        = $toolboxFactory->create();
 
-        $reflection = new ReflectionClass($toolbox);
-        $property   = $reflection->getProperty('tools');
-        $tools      = $property->getValue($toolbox);
-
-        self::assertCount(2, $tools);
-        self::assertSame($tool1, $tools[0]);
-        self::assertSame($tool2, $tools[1]);
+        self::assertCount(1, $toolbox->getMap());
     }
 }


### PR DESCRIPTION
Missing

- [x] Utilize `SettingsToolBox` in settings to read metadata of tools
- [x] Implement tool settings to the settings objects for customization of at least the general tool description 
- [x] Overwrite llm tool metadata in `SettingsToolBox` from the given application settings