### PR TITLE
Automatic refresh search index on Image and Document changes

### DIFF
--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -4,3 +4,6 @@ services:
 
   ChronicleKeeper\Shared\Infrastructure\Persistence\Filesystem\Contracts\Finder:
     class: ChronicleKeeper\Test\Shared\Infrastructure\Persistence\Filesystem\FinderDouble
+
+  ChronicleKeeper\Shared\Infrastructure\LLMChain\LLMChainFactory:
+    class: ChronicleKeeper\Test\Shared\Infrastructure\LLMChain\LLMChainFactoryDouble

--- a/src/Document/Application/Event/VectorStorageUpdater.php
+++ b/src/Document/Application/Event/VectorStorageUpdater.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Document\Application\Event;
+
+use ChronicleKeeper\Document\Domain\Event\DocumentChangedContent;
+use ChronicleKeeper\Document\Domain\Event\DocumentCreated;
+use ChronicleKeeper\Document\Infrastructure\VectorStorage\LibraryDocumentUpdater;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+class VectorStorageUpdater
+{
+    public function __construct(
+        private readonly LibraryDocumentUpdater $libraryDocumentUpdater,
+    ) {
+    }
+
+    #[AsEventListener]
+    public function updateOnDocumentContentChanged(DocumentChangedContent $event): void
+    {
+        $this->libraryDocumentUpdater->updateOrCreateVectorsForDocument($event->document);
+    }
+
+    #[AsEventListener]
+    public function createOnDocumentCreated(DocumentCreated $event): void
+    {
+        $this->libraryDocumentUpdater->updateOrCreateVectorsForDocument($event->document);
+    }
+}

--- a/src/Document/Infrastructure/VectorStorage/LibraryDocumentUpdater.php
+++ b/src/Document/Infrastructure/VectorStorage/LibraryDocumentUpdater.php
@@ -38,8 +38,10 @@ class LibraryDocumentUpdater
         }
     }
 
-    private function updateOrCreateVectorsForDocument(Document $document, int $contentLength): void
-    {
+    public function updateOrCreateVectorsForDocument(
+        Document $document,
+        int $contentLength = self::VECTOR_CONTENT_LENGTH,
+    ): void {
         $existingStorage = $this->queryService->query(new FindVectorsOfDocument($document->getId()));
 
         if ($existingStorage === []) {

--- a/src/Image/Application/Event/VectorStorageUpdater.php
+++ b/src/Image/Application/Event/VectorStorageUpdater.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Image\Application\Event;
+
+use ChronicleKeeper\Image\Domain\Event\ImageCreated;
+use ChronicleKeeper\Image\Domain\Event\ImageDescriptionUpdated;
+use ChronicleKeeper\Image\Infrastructure\VectorStorage\LibraryImageUpdater;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+class VectorStorageUpdater
+{
+    public function __construct(
+        private readonly LibraryImageUpdater $libraryImageUpdater,
+    ) {
+    }
+
+    #[AsEventListener]
+    public function updateOnImageChangedDescription(ImageDescriptionUpdated $event): void
+    {
+        $this->libraryImageUpdater->updateOrCreateVectorsForImage($event->image);
+    }
+
+    #[AsEventListener]
+    public function createOnImageCreation(ImageCreated $event): void
+    {
+        $this->libraryImageUpdater->updateOrCreateVectorsForImage($event->image);
+    }
+}

--- a/src/Image/Infrastructure/VectorStorage/LibraryImageUpdater.php
+++ b/src/Image/Infrastructure/VectorStorage/LibraryImageUpdater.php
@@ -32,7 +32,7 @@ class LibraryImageUpdater
         }
     }
 
-    private function updateOrCreateVectorsForImage(Image $image): void
+    public function updateOrCreateVectorsForImage(Image $image): void
     {
         $existingStorage = $this->vectorImageRepository->findAllByImageId($image->getId());
 

--- a/tests/Document/Application/Event/VectorStorageUpdaterTest.php
+++ b/tests/Document/Application/Event/VectorStorageUpdaterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Document\Application\Event;
+
+use ChronicleKeeper\Document\Application\Event\VectorStorageUpdater;
+use ChronicleKeeper\Document\Domain\Event\DocumentChangedContent;
+use ChronicleKeeper\Document\Domain\Event\DocumentCreated;
+use ChronicleKeeper\Document\Infrastructure\VectorStorage\LibraryDocumentUpdater;
+use ChronicleKeeper\Test\Document\Domain\Entity\DocumentBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(VectorStorageUpdater::class)]
+#[Small]
+final class VectorStorageUpdaterTest extends TestCase
+{
+    #[Test]
+    public function itUpdatesVectorsOnDocumentContentChanged(): void
+    {
+        $document = (new DocumentBuilder())->build();
+
+        $libraryDocumentUpdater = $this->createMock(LibraryDocumentUpdater::class);
+        $libraryDocumentUpdater->expects($this->once())
+            ->method('updateOrCreateVectorsForDocument')
+            ->with($document);
+
+        $updater = new VectorStorageUpdater($libraryDocumentUpdater);
+
+        $updater->updateOnDocumentContentChanged(new DocumentChangedContent($document, 'old content'));
+    }
+
+    #[Test]
+    public function itCreatesVectorsOnDocumentCreated(): void
+    {
+        $document = (new DocumentBuilder())->build();
+
+        $libraryDocumentUpdater = $this->createMock(LibraryDocumentUpdater::class);
+        $libraryDocumentUpdater->expects($this->once())
+            ->method('updateOrCreateVectorsForDocument')
+            ->with($document);
+
+        $updater = new VectorStorageUpdater($libraryDocumentUpdater);
+
+        $updater->createOnDocumentCreated(new DocumentCreated($document));
+    }
+}

--- a/tests/Image/Application/Event/VectorStorageUpdaterTest.php
+++ b/tests/Image/Application/Event/VectorStorageUpdaterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Image\Application\Event;
+
+use ChronicleKeeper\Image\Application\Event\VectorStorageUpdater;
+use ChronicleKeeper\Image\Domain\Event\ImageCreated;
+use ChronicleKeeper\Image\Domain\Event\ImageDescriptionUpdated;
+use ChronicleKeeper\Image\Infrastructure\VectorStorage\LibraryImageUpdater;
+use ChronicleKeeper\Test\Image\Domain\Entity\ImageBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(VectorStorageUpdater::class)]
+#[Small]
+final class VectorStorageUpdaterTest extends TestCase
+{
+    #[Test]
+    public function itUpdatesVectorsOnDocumentContentChanged(): void
+    {
+        $image = (new ImageBuilder())->build();
+
+        $libraryImageUpdater = $this->createMock(LibraryImageUpdater::class);
+        $libraryImageUpdater->expects($this->once())
+            ->method('updateOrCreateVectorsForImage')
+            ->with($image);
+
+        $updater = new VectorStorageUpdater($libraryImageUpdater);
+
+        $updater->updateOnImageChangedDescription(new ImageDescriptionUpdated($image, 'old content'));
+    }
+
+    #[Test]
+    public function itCreatesVectorsOnDocumentCreated(): void
+    {
+        $image = (new ImageBuilder())->build();
+
+        $libraryImageUpdater = $this->createMock(LibraryImageUpdater::class);
+        $libraryImageUpdater->expects($this->once())
+            ->method('updateOrCreateVectorsForImage')
+            ->with($image);
+
+        $updater = new VectorStorageUpdater($libraryImageUpdater);
+
+        $updater->createOnImageCreation(new ImageCreated($image));
+    }
+}

--- a/tests/Image/Infrastructure/VectorStorage/LibraryImageUpdaterTest.php
+++ b/tests/Image/Infrastructure/VectorStorage/LibraryImageUpdaterTest.php
@@ -7,8 +7,10 @@ namespace ChronicleKeeper\Test\Image\Infrastructure\VectorStorage;
 use ChronicleKeeper\Image\Infrastructure\VectorStorage\LibraryImageUpdater;
 use ChronicleKeeper\Library\Infrastructure\Repository\FilesystemImageRepository;
 use ChronicleKeeper\Library\Infrastructure\Repository\FilesystemVectorImageRepository;
+use ChronicleKeeper\Library\Infrastructure\VectorStorage\VectorImage;
 use ChronicleKeeper\Shared\Infrastructure\LLMChain\EmbeddingCalculator;
 use ChronicleKeeper\Test\Image\Domain\Entity\ImageBuilder;
+use ChronicleKeeper\Test\Image\Domain\Entity\VectorImageBuilder;
 use PhpLlm\LlmChain\Document\Vector;
 use PhpLlm\LlmChain\Model\Response\VectorResponse;
 use PhpLlm\LlmChain\PlatformInterface;
@@ -17,12 +19,187 @@ use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 
 #[CoversClass(LibraryImageUpdater::class)]
 #[Small]
 class LibraryImageUpdaterTest extends TestCase
 {
+    #[Test]
+    public function itDoesNothingWhenThereAreNoImages(): void
+    {
+        $imageRepository = $this->createMock(FilesystemImageRepository::class);
+        $imageRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([]);
+
+        $vectorImageRepository = $this->createMock(FilesystemVectorImageRepository::class);
+        $vectorImageRepository->expects($this->never())->method('findAllByImageId');
+        $vectorImageRepository->expects($this->never())->method('store');
+
+        $embeddingCalculator = $this->createMock(EmbeddingCalculator::class);
+        $embeddingCalculator->expects($this->never())->method('createTextChunks');
+        $embeddingCalculator->expects($this->never())->method('getMultipleEmbeddings');
+
+        $updater = new LibraryImageUpdater(
+            new NullLogger(),
+            $embeddingCalculator,
+            $imageRepository,
+            $vectorImageRepository,
+        );
+        $updater->updateAll();
+    }
+
+    #[Test]
+    public function itCreatesAVectorStorageIfThereWasNone(): void
+    {
+        $image = (new ImageBuilder())
+            ->withId('4aa2c8d3-3b74-451c-b19e-33d1f80227d5')
+            ->withDescription('This is a test image.')
+            ->build();
+
+        $imageRepository = $this->createMock(FilesystemImageRepository::class);
+        $imageRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([$image]);
+
+        $vectorImageRepository = $this->createMock(FilesystemVectorImageRepository::class);
+        $vectorImageRepository->expects($this->once())
+            ->method('findAllByImageId')
+            ->with('4aa2c8d3-3b74-451c-b19e-33d1f80227d5')
+            ->willReturn([]);
+
+        $invoker = $this->exactly(2);
+        $vectorImageRepository->expects($invoker)
+            ->method('store')
+            ->willReturnCallback(static function (VectorImage $vectorImage) use ($invoker): void {
+                if ($invoker->numberOfInvocations() === 1) {
+                    self::assertSame('This is a', $vectorImage->content);
+                    self::assertSame([10.1], $vectorImage->vector);
+                } else {
+                    self::assertSame('test image.', $vectorImage->content);
+                    self::assertSame([10.2], $vectorImage->vector);
+                }
+            });
+
+        $embeddingCalculator = $this->createMock(EmbeddingCalculator::class);
+        $embeddingCalculator->expects($this->once())
+            ->method('createTextChunks')
+            ->with('This is a test image.')
+            ->willReturn(['This is a', 'test image.']);
+
+        $embeddingCalculator->expects($this->once())
+            ->method('getMultipleEmbeddings')
+            ->with(['This is a', 'test image.'])
+            ->willReturn([[10.1], [10.2]]);
+
+        $updater = new LibraryImageUpdater(
+            new NullLogger(),
+            $embeddingCalculator,
+            $imageRepository,
+            $vectorImageRepository,
+        );
+        $updater->updateAll();
+    }
+
+    #[Test]
+    public function itDoesNothingForExistingStorageOnUnchangedContentHash(): void
+    {
+        $image = (new ImageBuilder())
+            ->withId('4aa2c8d3-3b74-451c-b19e-33d1f80227d5')
+            ->withDescription('This is a test image.')
+            ->build();
+
+        $vectorImage = (new VectorImageBuilder())
+            ->withImage($image)
+            ->withVectorContentHash($image->getDescriptionHash())
+            ->withVector([10.1])
+            ->build();
+
+        $imageRepository = $this->createMock(FilesystemImageRepository::class);
+        $imageRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([$image]);
+
+        $vectorImageRepository = $this->createMock(FilesystemVectorImageRepository::class);
+        $vectorImageRepository->expects($this->once())
+            ->method('findAllByImageId')
+            ->with('4aa2c8d3-3b74-451c-b19e-33d1f80227d5')
+            ->willReturn([$vectorImage]);
+        $vectorImageRepository->expects($this->never())->method('store');
+
+        $embeddingCalculator = $this->createMock(EmbeddingCalculator::class);
+        $embeddingCalculator->expects($this->never())->method('createTextChunks');
+        $embeddingCalculator->expects($this->never())->method('getMultipleEmbeddings');
+
+        $updater = new LibraryImageUpdater(
+            new NullLogger(),
+            $embeddingCalculator,
+            $imageRepository,
+            $vectorImageRepository,
+        );
+        $updater->updateAll();
+    }
+
+    #[Test]
+    public function itCleansTheVectorStorageAndRegeneratesIt(): void
+    {
+        $image = (new ImageBuilder())
+            ->withId('4aa2c8d3-3b74-451c-b19e-33d1f80227d5')
+            ->withDescription('This is a test image.')
+            ->build();
+
+        $vectorImage = (new VectorImageBuilder())
+            ->withImage($image)
+            ->withVectorContentHash('12345')
+            ->withVector([10.1])
+            ->build();
+
+        $imageRepository = $this->createMock(FilesystemImageRepository::class);
+        $imageRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([$image]);
+
+        $vectorImageRepository = $this->createMock(FilesystemVectorImageRepository::class);
+        $vectorImageRepository->expects($this->once())
+            ->method('findAllByImageId')
+            ->with('4aa2c8d3-3b74-451c-b19e-33d1f80227d5')
+            ->willReturn([$vectorImage]);
+
+        $invoker = $this->exactly(2);
+        $vectorImageRepository->expects($invoker)
+            ->method('store')
+            ->willReturnCallback(static function (VectorImage $vectorImage) use ($invoker): void {
+                if ($invoker->numberOfInvocations() === 1) {
+                    self::assertSame('This is a', $vectorImage->content);
+                    self::assertSame([10.1], $vectorImage->vector);
+                } else {
+                    self::assertSame('test image.', $vectorImage->content);
+                    self::assertSame([10.2], $vectorImage->vector);
+                }
+            });
+
+        $embeddingCalculator = $this->createMock(EmbeddingCalculator::class);
+        $embeddingCalculator->expects($this->once())
+            ->method('createTextChunks')
+            ->with('This is a test image.')
+            ->willReturn(['This is a', 'test image.']);
+
+        $embeddingCalculator->expects($this->once())
+            ->method('getMultipleEmbeddings')
+            ->with(['This is a', 'test image.'])
+            ->willReturn([[10.1], [10.2]]);
+
+        $updater = new LibraryImageUpdater(
+            new NullLogger(),
+            $embeddingCalculator,
+            $imageRepository,
+            $vectorImageRepository,
+        );
+        $updater->updateAll();
+    }
+
     #[Test]
     public function splitImagesIntoVectorChunks(): void
     {

--- a/tests/Shared/Infrastructure/LLMChain/LLMChainFactoryDouble.php
+++ b/tests/Shared/Infrastructure/LLMChain/LLMChainFactoryDouble.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Shared\Infrastructure\LLMChain;
+
+use ChronicleKeeper\Shared\Infrastructure\LLMChain\LLMChainFactory;
+use Override;
+use PhpLlm\LlmChain\ChainInterface;
+use PhpLlm\LlmChain\Model\Message\MessageBag;
+use PhpLlm\LlmChain\Model\Model;
+use PhpLlm\LlmChain\Model\Response\ResponseInterface;
+use PhpLlm\LlmChain\PlatformInterface;
+
+class LLMChainFactoryDouble extends LLMChainFactory
+{
+    /** @var array<class-string<Model>, ResponseInterface> */
+    private array $knownResponses = [];
+
+    /** @phpstan-ignore constructor.missingParentCall */
+    public function __construct()
+    {
+    }
+
+    #[Override]
+    public function create(): ChainInterface
+    {
+        return new class implements ChainInterface {
+            /** @inheritDoc */
+            public function call(MessageBag $messages, array $options = []): ResponseInterface
+            {
+                return new class implements ResponseInterface {
+                    public function getContent(): string
+                    {
+                        return 'Mocked Response';
+                    }
+                };
+            }
+        };
+    }
+
+    #[Override]
+    public function createPlatform(): PlatformInterface
+    {
+        $knownResponses = $this->knownResponses;
+
+        return new class ($knownResponses) implements PlatformInterface {
+            /** @param array<class-string<Model>, ResponseInterface> $knownResponses */
+            public function __construct(private readonly array $knownResponses = [])
+            {
+            }
+
+            /** @inheritDoc */
+            public function request(Model $model, mixed $input, array $options = []): ResponseInterface
+            {
+                return $this->knownResponses[$model::class] ?? new class implements ResponseInterface {
+                    public function getContent(): string
+                    {
+                        return 'Mocked Response';
+                    }
+                };
+            }
+        };
+    }
+
+    /** @param class-string<Model> $model */
+    public function addPlatformResponse(string $model, ResponseInterface $response): void
+    {
+        $this->knownResponses[$model] = $response;
+    }
+}


### PR DESCRIPTION
It was also needed now to create a test double for LLM Chain Calls so tests can deliver responses without doing real calls to the OpenAI API. 