### PR TITLE
Clear cache after directory import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Added**
 - Implemented a directory cache for better performance while browsing the library.
+- The directory cache will be fully cleared with every completed export to prevent inconsistencies between the cache and data.
 - Added a library header function to clear the directory cache manually.
 - The search index for documents and images of the library are now automized on changes, a global refresh is not generally needed anymore.
 - The file access now has a request based cache layer to improve file access performance.

--- a/src/Library/Application/Event/DirectoryCacheClear.php
+++ b/src/Library/Application/Event/DirectoryCacheClear.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Library\Application\Event;
+
+use ChronicleKeeper\Settings\Domain\Event\ImportFinished;
+use ChronicleKeeper\Shared\Infrastructure\Persistence\Filesystem\Contracts\FileAccess;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener]
+class DirectoryCacheClear
+{
+    public function __construct(
+        private readonly FileAccess $fileAccess,
+    ) {
+    }
+
+    public function __invoke(ImportFinished $event): void
+    {
+        $this->fileAccess->prune('library.directories.cache');
+    }
+}

--- a/src/Settings/Application/Service/Importer.php
+++ b/src/Settings/Application/Service/Importer.php
@@ -7,6 +7,7 @@ namespace ChronicleKeeper\Settings\Application\Service;
 use ChronicleKeeper\Settings\Application\Service\Importer\ImportedFileBag;
 use ChronicleKeeper\Settings\Application\Service\Importer\SingleImport;
 use ChronicleKeeper\Settings\Domain\Event\FileImported;
+use ChronicleKeeper\Settings\Domain\Event\ImportFinished;
 use League\Flysystem\Filesystem;
 use League\Flysystem\ZipArchive\FilesystemZipArchiveProvider;
 use League\Flysystem\ZipArchive\ZipArchiveAdapter;
@@ -54,6 +55,8 @@ class Importer
         }
 
         @unlink($archiveFile);
+
+        $this->eventDispatcher->dispatch(new ImportFinished($importSettings, $importedFiles));
 
         foreach ($importedFiles as $importedFile) {
             $this->eventDispatcher->dispatch(new FileImported($importSettings, $importedFile, $versionOfArchive));

--- a/src/Settings/Domain/Event/ImportFinished.php
+++ b/src/Settings/Domain/Event/ImportFinished.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Settings\Domain\Event;
+
+use ChronicleKeeper\Settings\Application\Service\Importer\ImportedFileBag;
+use ChronicleKeeper\Settings\Application\Service\ImportSettings;
+
+final readonly class ImportFinished
+{
+    public function __construct(
+        public ImportSettings $importSettings,
+        public ImportedFileBag $importedFileBag,
+    ) {
+    }
+}

--- a/src/Shared/Infrastructure/Persistence/Filesystem/CachedFileAccess.php
+++ b/src/Shared/Infrastructure/Persistence/Filesystem/CachedFileAccess.php
@@ -49,4 +49,10 @@ class CachedFileAccess implements FileAccessContract
 
         $this->fileAccess->delete($type, $filename);
     }
+
+    public function prune(string $type): void
+    {
+        unset($this->cachedFiles[$type]);
+        $this->fileAccess->prune($type);
+    }
 }

--- a/src/Shared/Infrastructure/Persistence/Filesystem/Contracts/FileAccess.php
+++ b/src/Shared/Infrastructure/Persistence/Filesystem/Contracts/FileAccess.php
@@ -43,4 +43,7 @@ interface FileAccess
      * @throws UnableToDeleteFile
      */
     public function delete(string $type, string $filename): void;
+
+    /** @param non-empty-string $type */
+    public function prune(string $type): void;
 }

--- a/src/Shared/Infrastructure/Persistence/Filesystem/FileAccess.php
+++ b/src/Shared/Infrastructure/Persistence/Filesystem/FileAccess.php
@@ -70,6 +70,17 @@ class FileAccess implements FileAccessContract
         }
     }
 
+    public function prune(string $type): void
+    {
+        $path = $this->pathRegistry->get($type);
+        if (! $this->filesystem->exists($path)) {
+            return;
+        }
+
+        // Remove the directory, so all files in it will also be removed
+        $this->filesystem->remove($path);
+    }
+
     private function buildPath(string $type, string $filename): string
     {
         return $this->pathRegistry->get($type) . DIRECTORY_SEPARATOR . $filename;

--- a/tests/Library/Application/Event/DirectoryCacheClearTest.php
+++ b/tests/Library/Application/Event/DirectoryCacheClearTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Library\Application\Event;
+
+use ChronicleKeeper\Library\Application\Event\DirectoryCacheClear;
+use ChronicleKeeper\Settings\Application\Service\Importer\ImportedFileBag;
+use ChronicleKeeper\Settings\Application\Service\ImportSettings;
+use ChronicleKeeper\Settings\Domain\Event\ImportFinished;
+use ChronicleKeeper\Shared\Infrastructure\Persistence\Filesystem\Contracts\FileAccess;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DirectoryCacheClear::class)]
+#[Small]
+final class DirectoryCacheClearTest extends TestCase
+{
+    #[Test]
+    public function itClearsTheCache(): void
+    {
+        $fileAccess = $this->createMock(FileAccess::class);
+        $fileAccess->expects($this->once())->method('prune')->with('library.directories.cache');
+
+        $event               = new ImportFinished(new ImportSettings(), new ImportedFileBag());
+        $directoryCacheClear = new DirectoryCacheClear($fileAccess);
+        $directoryCacheClear($event);
+    }
+}

--- a/tests/Settings/Domain/Event/ImportFinishedTest.php
+++ b/tests/Settings/Domain/Event/ImportFinishedTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Settings\Domain\Event;
+
+use ChronicleKeeper\Settings\Application\Service\Importer\ImportedFileBag;
+use ChronicleKeeper\Settings\Application\Service\ImportSettings;
+use ChronicleKeeper\Settings\Domain\Event\ImportFinished;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ImportFinished::class)]
+#[Small]
+final class ImportFinishedTest extends TestCase
+{
+    #[Test]
+    public function itAllowsConstruction(): void
+    {
+        $importSettings  = self::createStub(ImportSettings::class);
+        $importedFileBag = new ImportedFileBag();
+
+        $event = new ImportFinished($importSettings, $importedFileBag);
+
+        self::assertSame($importSettings, $event->importSettings);
+        self::assertSame($importedFileBag, $event->importedFileBag);
+    }
+}

--- a/tests/Shared/Infrastructure/Persistence/Filesystem/CachedFileAccessTest.php
+++ b/tests/Shared/Infrastructure/Persistence/Filesystem/CachedFileAccessTest.php
@@ -65,4 +65,22 @@ final class CachedFileAccessTest extends TestCase
         $cachedFileAccess->delete('type', 'filename');
         self::assertFalse($cachedFileAccess->exists('type', 'filename'));
     }
+
+    #[Test]
+    public function itPrunesCachedEntries(): void
+    {
+        $fileAccess = $this->createMock(FileAccess::class);
+        $fileAccess->expects($this->never())->method('read');
+        $fileAccess->expects($this->once())->method('prune')->with('type');
+
+        $cachedFileAccess = new CachedFileAccess($fileAccess);
+
+        // Write file and ensure it is cached
+        $cachedFileAccess->write('type', 'filename', 'content');
+        self::assertTrue($cachedFileAccess->exists('type', 'filename'));
+
+        // Prune files and ensure they are no longer cached
+        $cachedFileAccess->prune('type');
+        self::assertFalse($cachedFileAccess->exists('type', 'filename'));
+    }
 }

--- a/tests/Shared/Infrastructure/Persistence/Filesystem/FileAccessDouble.php
+++ b/tests/Shared/Infrastructure/Persistence/Filesystem/FileAccessDouble.php
@@ -72,6 +72,11 @@ class FileAccessDouble implements FileAccess, ResetInterface
         $this->storage = [];
     }
 
+    public function prune(string $type): void
+    {
+        unset($this->storage[$type]);
+    }
+
     private function getPath(string $type, string $filename): string
     {
         return $type . '/' . $filename;

--- a/tests/Shared/Infrastructure/Persistence/Filesystem/FileAccessTest.php
+++ b/tests/Shared/Infrastructure/Persistence/Filesystem/FileAccessTest.php
@@ -153,4 +153,51 @@ class FileAccessTest extends TestCase
 
         self::assertFalse($result);
     }
+
+    #[Test]
+    public function prune(): void
+    {
+        $type = 'documents';
+        $path = '/var/www/data/documents';
+
+        $this->pathRegistry->expects($this->once())
+            ->method('get')
+            ->with($type)
+            ->willReturn('/var/www/data/documents');
+
+        $this->filesystem
+            ->expects($this->once())
+            ->method('exists')
+            ->with($path)
+            ->willReturn(true);
+
+        $this->filesystem
+            ->expects($this->once())
+            ->method('remove')
+            ->with($path);
+
+        $this->fileAccess->prune($type);
+    }
+
+    #[Test]
+    public function pruneWhenDirectoryNotExists(): void
+    {
+        $type = 'documents';
+        $path = '/var/www/data/documents';
+
+        $this->pathRegistry
+            ->expects($this->once())
+            ->method('get')
+            ->with($type)
+            ->willReturn('/var/www/data/documents');
+
+        $this->filesystem
+            ->method('exists')
+            ->with($path)
+            ->willReturn(false);
+
+        $this->filesystem->expects($this->never())->method('remove');
+
+        $this->fileAccess->prune($type);
+    }
 }


### PR DESCRIPTION
The cache is based on the current files within the library. After an import this is not in sync and can with a high possibility lead to exceptions because the library searches for, in the import, non existent files that were populated as existing from the cache.

To solve this the importer should have a hook to implement a cache clear without rebuilding it. 