### PR TITLE
Releases for Symfony CLI on Windows as PHPDesktop alternative

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@ phpcs.xml.dist export-ignore
 phpstan.neon export-ignore
 phpunit.xml.dist export-ignore
 Makefile export-ignore
+rector.php export-ignore

--- a/.github/workflows/symfony-cli-widows.yml
+++ b/.github/workflows/symfony-cli-widows.yml
@@ -1,4 +1,4 @@
-name: Build PHPDesktop Archive
+name: Build Symfony CLI Package for Windows
 
 on:
   release:
@@ -8,8 +8,8 @@ permissions:
   contents: write
 
 jobs:
-  phpdesktop:
-    name: build phpdesktop
+  symfony-cli-windows:
+    name: build symfony-cli-windows
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -19,19 +19,19 @@ jobs:
           php-version: '8.3'
 
       - name: do application build
-        run: make phpdesktop
+        run: make symfony-cli
 
       - name: Archive Release
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: 'zip'
-          command: 'mv build/ ChronicleKeeper-Desktop-${{ github.ref_name }}/'
-          path: "ChronicleKeeper-Desktop-${{ github.ref_name }}"
-          filename: "ChronicleKeeper-Desktop-${{ github.ref_name }}.zip"
+          command: 'mv build/ ChronicleKeeper-Server-Windows-${{ github.ref_name }}/'
+          path: "ChronicleKeeper-Server-Windows-${{ github.ref_name }}"
+          filename: "ChronicleKeeper-Server-Windows-${{ github.ref_name }}.zip"
 
       - name: Upload Release
         uses: ncipollo/release-action@v1.12.0
         with:
           allowUpdates: true
           omitBodyDuringUpdate: true
-          artifacts: "ChronicleKeeper-Desktop-${{ github.ref_name }}.zip"
+          artifacts: "ChronicleKeeper-Server-Windows-${{ github.ref_name }}.zip"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,27 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+symfony: ## build a symfony cli backed release
+	rm -rf build
+
+	mkdir -p build/php
+	cd build/php; wget https://windows.php.net/downloads/releases/latest/php-8.3-nts-Win32-vs16-x64-latest.zip
+	cd build/php; unzip php-8.3-nts-Win32-vs16-x64-latest.zip
+	cd build/php; rm php-8.3-nts-Win32-vs16-x64-latest.zip
+
+	cd build; wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.10.6/symfony-cli_windows_amd64.zip
+	cd build; unzip symfony-cli_windows_amd64.zip
+	cd build; rm symfony-cli_windows_amd64.zip
+	cd build; rm README.md LICENSE
+
+	git archive HEAD | (cd build/www; tar x)
+	cd build/www; APP_ENV=prod composer install --optimize-autoloader --no-dev --prefer-dist --no-progress
+	cd build/www; APP_ENV=prod php bin/console asset-map:compile
+	cd build/www; APP_ENV=prod php bin/console cache:warmup
+	cd build/www; rm composer.lock composer.json
+
+	cd build; cp www/config/symfony/chronicle-keeper.bat ChronicleKeeper.bat
+
 phpdesktop: ## build phpdesktop release
 	rm -rf build
 	wget https://github.com/syracine69/phpdesktop/releases/download/chrome-v99.0-php7.4/php-desktop-chrome-99.0-rc-php-7.4.28.zip

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-symfony: ## build a symfony cli backed release
+symfony-cli: ## build a symfony cli backed release
 	rm -rf build
 
 	mkdir -p build/php
@@ -20,13 +20,14 @@ symfony: ## build a symfony cli backed release
 	cd build; rm symfony-cli_windows_amd64.zip
 	cd build; rm README.md LICENSE
 
+	mkdir -p build/www
 	git archive HEAD | (cd build/www; tar x)
 	cd build/www; APP_ENV=prod composer install --optimize-autoloader --no-dev --prefer-dist --no-progress
 	cd build/www; APP_ENV=prod php bin/console asset-map:compile
 	cd build/www; APP_ENV=prod php bin/console cache:warmup
 	cd build/www; rm composer.lock composer.json
 
-	cd build; cp www/config/symfony/chronicle-keeper.bat ChronicleKeeper.bat
+	cd build; cp www/config/symfony-cli/chronicle-keeper.bat ChronicleKeeper.bat
 
 phpdesktop: ## build phpdesktop release
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ symfony-cli: ## build a symfony cli backed release
 
 	mkdir -p build/www
 	git archive HEAD | (cd build/www; tar x)
+	cd build/www; mv config/phpdesktop/php.ini ../php
 	cd build/www; APP_ENV=prod composer install --optimize-autoloader --no-dev --prefer-dist --no-progress
 	cd build/www; APP_ENV=prod php bin/console asset-map:compile
 	cd build/www; APP_ENV=prod php bin/console cache:warmup

--- a/config/phpdesktop/php.ini
+++ b/config/phpdesktop/php.ini
@@ -7,11 +7,9 @@ extension=php_sqlite3.dll
 extension=php_com_dotnet.dll
 extension=php_fileinfo.dll
 extension=php_mbstring.dll
-extension=php_gd2.dll
+extension=php_gd.dll
 extension=php_intl.dll
 extension=php_zip.dll
-extension=php_fileinfo.dll
-extension=php_intl.dll
 extension=php_tidy.dll
 
 ; Error Handliung

--- a/config/symfony-cli/chronicle-keeper.bat
+++ b/config/symfony-cli/chronicle-keeper.bat
@@ -1,0 +1,40 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+echo "Starting Chronicle Keeper with Symfony web server locally, please wait..."
+
+REM Silently kill existing processes
+taskkill /F /IM symfony.exe >nul 2>&1
+taskkill /F /IM php.exe >nul 2>&1
+timeout /t 2 >nul
+
+REM Check prerequisites silently
+if not exist "%~dp0php" exit /b 1
+if not exist "symfony.exe" exit /b 1
+
+REM Setup PATH
+SET OLD_PATH=%PATH%
+SET PATH=%PATH%;%~dp0php
+
+REM Start server and capture output
+start /B .\symfony.exe local:server:start --no-tls --dir .\www\ >nul 2>&1
+timeout /t 5 >nul
+
+REM Launch browser directly
+start "" "http://127.0.0.1:8000"
+
+echo "Chronicle Keeper is started, a browser window should have been opened, close window to stop server."
+
+REM Monitor server silently
+:mainloop
+tasklist /FI "IMAGENAME eq symfony.exe" 2>nul | find /I /N "symfony.exe" >nul
+if "%ERRORLEVEL%"=="1" goto cleanup
+timeout /t 2 >nul
+goto mainloop
+
+:cleanup
+taskkill /F /IM symfony.exe >nul 2>&1
+taskkill /F /IM php.exe >nul 2>&1
+SET PATH=%OLD_PATH%
+endlocal
+exit /b 0


### PR DESCRIPTION
The PHPDesktop release is really slow compared to a symfony development server. Even if the server should not be utilized for productive usage it is a currently good alternative for a windows deployment becasue of the performance boost. 