### PR TITLE
fix: Modal loading from bootstrap js defects tabler js

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,3 +1,9 @@
+// Vendors
+import './helpers/bootstrap.js';
+
+// Own Stuff
 import './bootstrap.js';
 import './css/app.css';
 import './css/messages.css';
+
+

--- a/assets/helpers/bootstrap.js
+++ b/assets/helpers/bootstrap.js
@@ -1,0 +1,97 @@
+/**
+ * Workaround for Tabler Bug https://github.com/tabler/tabler/issues/1865
+ *
+ * The bug occurs because in the confirm dialog the bootstrap modal loading would conflict with tabler js
+ * so we render the needed bootstrap js ourselves because most of the js from tabler is not a hard requirement
+ */
+import {
+    Alert,
+    Button,
+    Carousel,
+    Collapse,
+    Dropdown,
+    Modal,
+    Offcanvas,
+    Popover,
+    ScrollSpy,
+    Tab,
+    Toast,
+    Tooltip,
+} from "bootstrap";
+
+// Initialize Bootstrap components
+const initializeComponent = (selector, Component) => {
+    document.querySelectorAll(selector).forEach((element) => {
+        try {
+            if (Component.name === "Tooltip" || Component.name === "Popover") {
+                // For Tooltip and Popover, pass options if necessary
+                const options = {}; // Add any custom options here if needed
+                new Component(element, options);
+            } else {
+                // Default initialization for other components
+                new Component(element);
+            }
+        } catch (error) {
+            console.error(`Failed to initialize ${Component.name}:`, error);
+        }
+    });
+};
+
+// Map of components and their selectors
+const components = {
+    '[data-bs-toggle="alert"]': Alert,
+    '[data-bs-toggle="button"]': Button,
+    '[data-bs-toggle="carousel"]': Carousel,
+    '[data-bs-toggle="collapse"]': Collapse,
+    '[data-bs-toggle="dropdown"]': Dropdown,
+    '[data-bs-toggle="modal"]': Modal,
+    '[data-bs-toggle="offcanvas"]': Offcanvas,
+    '[data-bs-toggle="popover"]': Popover,
+    '[data-bs-toggle="scrollspy"]': ScrollSpy,
+    '[data-bs-toggle="tab"]': Tab,
+    '[data-bs-toggle="toast"]': Toast,
+    '[data-bs-toggle="tooltip"]': Tooltip,
+};
+
+const install = (app) => {
+    // Initialize all components after Vue app is mounted
+    app.mixin({
+        mounted() {
+            Object.entries(components).forEach(([selector, Component]) => {
+                initializeComponent(selector, Component);
+            });
+
+        },
+    });
+};
+
+// Export components
+export {
+    Alert,
+    Button,
+    Carousel,
+    Collapse,
+    Dropdown,
+    Modal,
+    Offcanvas,
+    Popover,
+    ScrollSpy,
+    Tab,
+    Toast,
+    Tooltip,
+};
+
+export default {
+    Alert,
+    Button,
+    Carousel,
+    Collapse,
+    Dropdown,
+    Modal,
+    Offcanvas,
+    Popover,
+    ScrollSpy,
+    Tab,
+    Toast,
+    Tooltip,
+};

--- a/importmap.php
+++ b/importmap.php
@@ -85,14 +85,18 @@ return [
         'version' => '2.4.1',
         'type' => 'css',
     ],
-    'bootstrap' => [
-        'version' => '5.3.3',
-    ],
     '@popperjs/core' => [
         'version' => '2.11.8',
     ],
     'bootstrap/dist/css/bootstrap.min.css' => [
         'version' => '5.3.3',
         'type' => 'css',
+    ],
+    '@tabler/core/dist/css/tabler.min.css' => [
+        'version' => '1.0.0',
+        'type' => 'css',
+    ],
+    'bootstrap' => [
+        'version' => '5.3.3',
     ],
 ];

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -6,9 +6,8 @@
     <link rel="icon" href="{{ asset('favicon.ico') }}" type="image/x-icon">
     <title>Der Chronicle Keeper - Rollenspiel Chatbot - Wissenbewahrer</title>
 
-    <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta21/dist/js/tabler.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta21/dist/css/tabler.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta21/dist/css/tabler-vendors.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0/dist/css/tabler.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0/dist/css/tabler-vendors.min.css">
 
     {% block stylesheets %}
     {% endblock %}


### PR DESCRIPTION
## Problem Statement

With v0.7 a new modal for confirmation dialog was implemented. This was done with instantiating the bootstrap modal within the stimulus controller for this feature. Sadly the import of this brakes the tabler.js from working. 

It is a known bug in https://github.com/tabler/tabler/issues/1865 

## Example
- Go to library, try to delete a medium here and you should see the confirmation dialog, fine
- Within the library click on the header button for additional actions, no dropdown is opened

## Implementation Details
- Build a workaround to make the tabler js not needed and load bootstrap js fully manually
- Remove tabler js loading and replace with the workaround