### PR TITLE
feat: Unify form buttons into a single file and offer more options

### DIFF
--- a/assets/controllers/loader_controller.js
+++ b/assets/controllers/loader_controller.js
@@ -21,9 +21,7 @@ export default class extends Controller {
 
             if (form && !isLiveActionForm) {
                 form.addEventListener('submit', (event) => {
-                    event.preventDefault();
                     showLoader();
-                    form.submit();
                 });
             }
         };

--- a/src/Document/Presentation/Controller/DocumentCreation.php
+++ b/src/Document/Presentation/Controller/DocumentCreation.php
@@ -16,6 +16,7 @@ use ChronicleKeeper\Library\Domain\RootDirectory;
 use ChronicleKeeper\Shared\Application\Query\QueryService;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\Alert;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\HandleFlashMessages;
+use ChronicleKeeper\Shared\Presentation\Twig\Form\HandleFooterButtonGroup;
 use PhpLlm\LlmChain\Model\Message\AssistantMessage;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -37,6 +38,7 @@ use function reset;
 class DocumentCreation extends AbstractController
 {
     use HandleFlashMessages;
+    use HandleFooterButtonGroup;
 
     public function __construct(
         private readonly QueryService $queryService,
@@ -54,14 +56,13 @@ class DocumentCreation extends AbstractController
             assert($document instanceof Document);
 
             $this->bus->dispatch(new StoreDocument($document));
+            $this->addFlashMessage($request, Alert::SUCCESS, 'Das Dokument wurde erfolgreich erstellt.');
 
-            $this->addFlashMessage(
+            return $this->redirectFromFooter(
                 $request,
-                Alert::SUCCESS,
-                'Das Dokument wurde erstellt, damit es in der Suche aktiv ist kannst du den Suchindex aktualisieren.',
+                $this->generateUrl('library', ['directory' => $document->getDirectory()->getId()]),
+                $this->generateUrl('library_document_view', ['document' => $document->getId()]),
             );
-
-            return $this->redirectToRoute('library', ['directory' => $document->getDirectory()->getId()]);
         }
 
         return $this->render(

--- a/src/Document/Presentation/Controller/DocumentEdit.php
+++ b/src/Document/Presentation/Controller/DocumentEdit.php
@@ -9,6 +9,7 @@ use ChronicleKeeper\Document\Domain\Entity\Document;
 use ChronicleKeeper\Document\Presentation\Form\DocumentType;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\Alert;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\HandleFlashMessages;
+use ChronicleKeeper\Shared\Presentation\Twig\Form\HandleFooterButtonGroup;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,6 +25,7 @@ use Symfony\Component\Routing\Requirement\Requirement;
 class DocumentEdit extends AbstractController
 {
     use HandleFlashMessages;
+    use HandleFooterButtonGroup;
 
     public function __construct(
         private readonly MessageBusInterface $bus,
@@ -41,10 +43,14 @@ class DocumentEdit extends AbstractController
             $this->addFlashMessage(
                 $request,
                 Alert::SUCCESS,
-                'Das geänderte Dokument wurde in der Bbiliothek hinterlegt und steht in deinen Gesprächen nun zur Verfügung.',
+                'Das geänderte Dokument wurde erfolgreich gespeichert.',
             );
 
-            return $this->redirectToRoute('library', ['directory' => $document->getDirectory()->getId()]);
+            return $this->redirectFromFooter(
+                $request,
+                $this->generateUrl('library', ['directory' => $document->getDirectory()->getId()]),
+                $this->generateUrl('library_document_view', ['document' => $document->getId()]),
+            );
         }
 
         return $this->render(

--- a/src/Document/Presentation/Controller/DocumentUpload.php
+++ b/src/Document/Presentation/Controller/DocumentUpload.php
@@ -11,6 +11,7 @@ use ChronicleKeeper\Library\Domain\Entity\Directory;
 use ChronicleKeeper\Settings\Domain\Entity\SystemPrompt;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\Alert;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\HandleFlashMessages;
+use ChronicleKeeper\Shared\Presentation\Twig\Form\HandleFooterButtonGroup;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -30,6 +31,7 @@ use function is_bool;
 class DocumentUpload extends AbstractController
 {
     use HandleFlashMessages;
+    use HandleFooterButtonGroup;
 
     public function __construct(
         private readonly FormFactoryInterface $formFactory,
@@ -58,10 +60,15 @@ class DocumentUpload extends AbstractController
                 $this->addFlashMessage(
                     $request,
                     Alert::SUCCESS,
-                    'Das Dokument mit dem Titel "' . $document->getTitle() . '" wurde erfolgreich hochgeladen. Bitte überprüfe den Text nach einer Optimierung.',
+                    'Das Dokument mit dem Titel "' . $document->getTitle() . '" wurde erfolgreich hochgeladen.',
                 );
 
-                return $this->redirectToRoute('library_document_view', ['document' => $document->getId()]);
+                return $this->redirectFromFooter(
+                    $request,
+                    $this->generateUrl('library', ['directory' => $document->getDirectory()->getId()]),
+                    $this->generateUrl('library_document_view', ['document' => $document->getId()]),
+                    $this->generateUrl('library_document_upload', ['directory' => $document->getDirectory()->getId()]),
+                );
             } catch (PDFHasEmptyContent) {
                 $this->addFlashMessage(
                     $request,

--- a/src/Library/Presentation/Controller/Directory/DirectoryCreation.php
+++ b/src/Library/Presentation/Controller/Directory/DirectoryCreation.php
@@ -9,15 +9,14 @@ use ChronicleKeeper\Library\Domain\Entity\Directory;
 use ChronicleKeeper\Library\Presentation\Form\DirectoryType;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\Alert;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\HandleFlashMessages;
+use ChronicleKeeper\Shared\Presentation\Twig\Form\HandleFooterButtonGroup;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Requirement\Requirement;
-use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
 
 use function array_key_exists;
@@ -32,10 +31,10 @@ use function is_array;
 class DirectoryCreation extends AbstractController
 {
     use HandleFlashMessages;
+    use HandleFooterButtonGroup;
 
     public function __construct(
         private readonly Environment $environment,
-        private readonly RouterInterface $router,
         private readonly FormFactoryInterface $formFactory,
         private readonly MessageBusInterface $bus,
     ) {
@@ -59,10 +58,15 @@ class DirectoryCreation extends AbstractController
                 'Das Verzeichnis "' . $directory->getTitle() . '" wurde erfolgreich erstellt.',
             );
 
-            return new RedirectResponse($this->router->generate(
-                'library',
-                ['directory' => $directory->getId()],
-            ));
+            return $this->redirectFromFooter(
+                $request,
+                $this->generateUrl('library', ['directory' => $directory->getParent()?->getId()]),
+                $this->generateUrl('library', ['directory' => $directory->getId()]),
+                $this->generateUrl(
+                    'library_directory_create',
+                    ['parentDirectory' => $directory->getParent()?->getId()],
+                ),
+            );
         }
 
         return new Response(

--- a/src/Library/Presentation/Controller/Image/ImageUpload.php
+++ b/src/Library/Presentation/Controller/Image/ImageUpload.php
@@ -10,16 +10,15 @@ use ChronicleKeeper\Library\Presentation\Form\ImageUploadType;
 use ChronicleKeeper\Settings\Domain\Entity\SystemPrompt;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\Alert;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\HandleFlashMessages;
+use ChronicleKeeper\Shared\Presentation\Twig\Form\HandleFooterButtonGroup;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Routing\RouterInterface;
-use Twig\Environment;
 
 use function assert;
 
@@ -31,9 +30,9 @@ use function assert;
 class ImageUpload extends AbstractController
 {
     use HandleFlashMessages;
+    use HandleFooterButtonGroup;
 
     public function __construct(
-        private readonly Environment $environment,
         private readonly FormFactoryInterface $formFactory,
         private readonly Uploader $uploader,
         private readonly RouterInterface $router,
@@ -60,12 +59,17 @@ class ImageUpload extends AbstractController
                 'Das Bild mit dem Titel "' . $image->getTitle() . '" wurde erfolgreich hochgeladen. Bitte überprüfe die inhaltliche Beschreibung.',
             );
 
-            return new RedirectResponse($this->router->generate('library_image_view', ['image' => $image->getId()]));
+            return $this->redirectFromFooter(
+                $request,
+                $this->router->generate('library', ['directory' => $image->getDirectory()->getId()]),
+                $this->router->generate('library_image_view', ['image' => $image->getId()]),
+                $this->router->generate('library_image_upload', ['directory' => $image->getDirectory()->getId()]),
+            );
         }
 
-        return new Response($this->environment->render(
+        return $this->render(
             'library/image_upload.html.twig',
             ['directory' => $directory, 'form' => $form->createView()],
-        ));
+        );
     }
 }

--- a/src/Shared/Presentation/Twig/Form/FooterButtonGroup.php
+++ b/src/Shared/Presentation/Twig/Form/FooterButtonGroup.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Shared\Presentation\Twig\Form;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent(
+    name: 'Form:FotterButtonGroup',
+    template: 'components/shared/form/footer-button-group.html.twig',
+)]
+class FooterButtonGroup
+{
+    public string|null $cancelLink    = null;
+    public bool $showRedirectToCreate = true;
+    public bool $showRedirectToView   = true;
+}

--- a/src/Shared/Presentation/Twig/Form/HandleFooterButtonGroup.php
+++ b/src/Shared/Presentation/Twig/Form/HandleFooterButtonGroup.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Shared\Presentation\Twig\Form;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use function method_exists;
+
+trait HandleFooterButtonGroup
+{
+    private function redirectFromFooter(
+        Request $request,
+        string $redirectToList,
+        string $redirectToView,
+        string|null $redirectToCreate = null,
+    ): Response {
+        if (! method_exists($this, 'redirectToRoute')) { // @phpstan-ignore function.alreadyNarrowedType
+            throw new RuntimeException('The controller must extend ' . AbstractController::class);
+        }
+
+        if (! $request->request->has('saveAndRedirect')) {
+            return new RedirectResponse($redirectToList);
+        }
+
+        $saveAndRedirect = $request->request->get('saveAndRedirect');
+
+        return match ($saveAndRedirect) {
+            '1' => new RedirectResponse($redirectToView),
+            '2' => new RedirectResponse($redirectToCreate ?? throw new InvalidArgumentException('There is no create redirection route given')),
+             default => new RedirectResponse($redirectToList),
+        };
+    }
+}

--- a/src/World/Presentation/Controller/WorldItemCreate.php
+++ b/src/World/Presentation/Controller/WorldItemCreate.php
@@ -6,6 +6,7 @@ namespace ChronicleKeeper\World\Presentation\Controller;
 
 use ChronicleKeeper\Shared\Presentation\FlashMessages\Alert;
 use ChronicleKeeper\Shared\Presentation\FlashMessages\HandleFlashMessages;
+use ChronicleKeeper\Shared\Presentation\Twig\Form\HandleFooterButtonGroup;
 use ChronicleKeeper\World\Application\Command\StoreWorldItem;
 use ChronicleKeeper\World\Domain\Entity\Item;
 use ChronicleKeeper\World\Presentation\Form\WorldItemType;
@@ -21,6 +22,7 @@ use function assert;
 final class WorldItemCreate extends AbstractController
 {
     use HandleFlashMessages;
+    use HandleFooterButtonGroup;
 
     public function __invoke(Request $request, MessageBusInterface $bus): Response
     {
@@ -39,7 +41,12 @@ final class WorldItemCreate extends AbstractController
                 'Der Eintrag wurde erfolgreich erstellt.',
             );
 
-            return $this->redirectToRoute('world_item_listing');
+            return $this->redirectFromFooter(
+                $request,
+                $this->generateUrl('world_item_listing'),
+                $this->generateUrl('world_item_view', ['id' => $item->getId()]),
+                $this->generateUrl('world_item_create'),
+            );
         }
 
         return $this->render(

--- a/templates/components/shared/form/footer-button-group.html.twig
+++ b/templates/components/shared/form/footer-button-group.html.twig
@@ -1,0 +1,35 @@
+<div class="d-flex">
+    {% if cancelLink is defined and cancelLink is not empty %}
+        <a href="{{ cancelLink }}" class="btn btn-ghost-secondary">{{ ux_icon('tabler:cancel') }}Abbrechen</a>
+    {% endif %}
+    <div class="ms-auto align-items-end">
+        <div class="btn-group">
+
+            <button type="submit"
+                    name="saveAndRedirect"
+                    value="0"
+                    class="btn btn-primary"
+                    title="Speichern und zurück zur Liste"
+            >{{ ux_icon('tabler:check') }}Speichern</button>
+
+            {% if showRedirectToView %}
+                <button type="submit"
+                        name="saveAndRedirect"
+                        value="1"
+                        class="btn btn-outline-primary"
+                        title="Speichern und weiter zur Detailansicht"
+                >{{ ux_icon('tabler:search') }}Speichern und Ansehen</button>
+            {% endif %}
+
+            {% if showRedirectToCreate %}
+                <button type="submit"
+                        name="saveAndRedirect"
+                        value="2"
+                        class="btn btn-outline-primary"
+                        title="Speichern und weiteren Eintrag anlegen"
+                >{{ ux_icon('tabler:plus') }}Speichern und Weiter</button>
+            {% endif %}
+
+        </div>
+    </div>
+</div>

--- a/templates/components/world/add_relation_to_world.html.twig
+++ b/templates/components/world/add_relation_to_world.html.twig
@@ -39,6 +39,10 @@
         </div>
     </div>
     <div class="modal-footer">
-        <button type="submit" class="btn btn-primary ms-auto" data-bs-dismiss="modal">Speichern</button>
+        <button
+            type="submit"
+            class="btn btn-primary ms-auto"
+            data-bs-dismiss="modal"
+        >{{ ux_icon('tabler:check') }}Speichern</button>
     </div>
 </form>

--- a/templates/document/document_create.html.twig
+++ b/templates/document/document_create.html.twig
@@ -31,10 +31,12 @@
                         </div>
                     </div>
                     <div class="card-footer text-end">
-                        <div class="d-flex">
-                            <a href="{{ path('library', {'directory': form.directory.vars.value }) }}" class="btn btn-link">Abbruch</a>
-                            <button type="submit" class="btn btn-primary ms-auto">Speichern</button>
-                        </div>
+                        {{ component('Form:FotterButtonGroup',
+                            {
+                                'cancelLink': path('library', {'directory': form.directory.vars.value }),
+                                'showRedirectToCreate': false
+                            }
+                        ) }}
                     </div>
                 </form>
             </div>

--- a/templates/document/document_edit.html.twig
+++ b/templates/document/document_edit.html.twig
@@ -30,10 +30,12 @@
                         </div>
                     </div>
                     <div class="card-footer text-end">
-                        <div class="d-flex">
-                            <a href="{{ path('library', {'directory': form.directory.vars.value }) }}" class="btn btn-link">Abbruch</a>
-                            <button type="submit" class="btn btn-primary ms-auto">Speichern</button>
-                        </div>
+                        {{ component('Form:FotterButtonGroup',
+                            {
+                                'cancelLink': path('library_document_view', {'document': document.id }),
+                                'showRedirectToCreate': false
+                            }
+                        ) }}
                     </div>
                 </form>
             </div>

--- a/templates/document/document_upload.html.twig
+++ b/templates/document/document_upload.html.twig
@@ -55,10 +55,11 @@
                             </div>
                         </div>
                         <div class="card-footer text-end">
-                            <div class="d-flex">
-                                <a href="{{ path('library', {'directory': directory.id }) }}" class="btn btn-link">Abbruch</a>
-                                <button type="submit" class="btn btn-primary ms-auto">Speichern</button>
-                            </div>
+                            {{ component('Form:FotterButtonGroup',
+                                {
+                                    'cancelLink': path('library', {'directory': directory.id }),
+                                }
+                            ) }}
                         </div>
                     </form>
                 </div>

--- a/templates/image_generator/create.html.twig
+++ b/templates/image_generator/create.html.twig
@@ -30,10 +30,13 @@
                         </div>
                     </div>
                     <div class="card-footer text-end">
-                        <div class="d-flex">
-                            <a href="{{ path('image_generator_overview') }}" class="btn btn-link">Abbruch</a>
-                            <button type="submit" class="btn btn-primary ms-auto">Weiter</button>
-                        </div>
+                        {{ component('Form:FotterButtonGroup',
+                            {
+                                'cancelLink': path('image_generator_overview'),
+                                'showRedirectToCreate': false,
+                                'showRedirectToView': false
+                            }
+                        ) }}
                     </div>
                 </div>
             </div>

--- a/templates/library/directory_create.html.twig
+++ b/templates/library/directory_create.html.twig
@@ -25,10 +25,10 @@
                             </div>
                         </div>
                         <div class="card-footer text-end">
-                            <div class="d-flex">
-                                <a href="{{ path('library', {'directory': parentDirectory.id }) }}" class="btn btn-link">Abbruch</a>
-                                <button type="submit" class="btn btn-primary ms-auto">Speichern</button>
-                            </div>
+                            {{ component(
+                                'Form:FotterButtonGroup',
+                                {'cancelLink': path('library', {'directory': parentDirectory.id })}
+                            ) }}
                         </div>
                     </form>
                 </div>

--- a/templates/library/image_upload.html.twig
+++ b/templates/library/image_upload.html.twig
@@ -25,10 +25,10 @@
                             </div>
                         </div>
                         <div class="card-footer text-end">
-                            <div class="d-flex">
-                                <a href="{{ path('library', {'directory': directory.id }) }}" class="btn btn-link">Abbruch</a>
-                                <button type="submit" class="btn btn-primary ms-auto">Speichern</button>
-                            </div>
+                            {{ component(
+                                'Form:FotterButtonGroup',
+                                {'cancelLink': path('library', {'directory': directory.id })}
+                            ) }}
                         </div>
                     </form>
                 </div>

--- a/templates/world/item_create.html.twig
+++ b/templates/world/item_create.html.twig
@@ -16,10 +16,10 @@
                             </div>
                         </div>
                         <div class="card-footer text-end">
-                            <div class="d-flex">
-                                <a href="{{ path('world_item_listing') }}" class="btn btn-link">Abbruch</a>
-                                <button type="submit" class="btn btn-primary ms-auto">Speichern</button>
-                            </div>
+                            {{ component(
+                                'Form:FotterButtonGroup',
+                                {'cancelLink': path('world_item_listing')}
+                            ) }}
                         </div>
                     </form>
                 </div>

--- a/tests/Document/Presentation/Controller/DocumentUploadTest.php
+++ b/tests/Document/Presentation/Controller/DocumentUploadTest.php
@@ -25,7 +25,6 @@ use function assert;
 use function mt_getrandmax;
 use function mt_rand;
 use function range;
-use function reset;
 
 #[CoversClass(DocumentUpload::class)]
 #[CoversClass(DocumentUploadType::class)]
@@ -85,8 +84,6 @@ class DocumentUploadTest extends WebTestCase
         // Check the new document is stored
         $documents = $this->databasePlatform->fetch('SELECT * FROM documents');
         self::assertCount(1, $documents);
-
-        $document = reset($documents);
-        self::assertResponseRedirects('/library/document/' . $document['id']);
+        self::assertResponseRedirects('/library');
     }
 }


### PR DESCRIPTION
Some forms need a bit more button options for user experience. For example the world items (database) are mostly that small that one wants to create a hole lot of entries at once. This would require a lot of clicks. So this PR brings a functionality for unified form footer buttons that contain multiple functions and a helper class for controllers to utilize the correct redirect after success of the form.

The result looks like the following and contains now four options:

- Cancel button that leads back to the corresponding list
- Save button that leads back to the correcponding list
- Save and view button that leads to the view mode of the created entry
- Save and continue button that will reopen a fresh form to create an additional entry

![image](https://github.com/user-attachments/assets/22c93177-f65e-4ff4-9c5c-0928952645c1)
