### PR TITLE
fix(Favorizer): target renaming events are ignored

### DIFF
--- a/src/Favorizer/Application/Event/TargetRenaming.php
+++ b/src/Favorizer/Application/Event/TargetRenaming.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Favorizer\Application\Event;
+
+use ChronicleKeeper\Chat\Domain\Event\ConversationRenamed;
+use ChronicleKeeper\Document\Domain\Event\DocumentRenamed;
+use ChronicleKeeper\Favorizer\Application\Command\StoreTargetBag;
+use ChronicleKeeper\Favorizer\Application\Query\GetTargetBag;
+use ChronicleKeeper\Favorizer\Domain\ValueObject\ChatConversationTarget;
+use ChronicleKeeper\Favorizer\Domain\ValueObject\LibraryDocumentTarget;
+use ChronicleKeeper\Favorizer\Domain\ValueObject\LibraryImageTarget;
+use ChronicleKeeper\Favorizer\Domain\ValueObject\WorldItemTarget;
+use ChronicleKeeper\Image\Domain\Event\ImageRenamed;
+use ChronicleKeeper\Shared\Application\Query\QueryService;
+use ChronicleKeeper\World\Domain\Event\ItemRenamed;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class TargetRenaming
+{
+    public function __construct(
+        private readonly QueryService $queryService,
+        private readonly MessageBusInterface $bus,
+    ) {
+    }
+
+    #[AsEventListener(ConversationRenamed::class)]
+    public function renameOnConversationRenamed(ConversationRenamed $event): void
+    {
+        $targetBag = $this->queryService->query(new GetTargetBag());
+        $target    = new ChatConversationTarget($event->conversation->getId(), $event->conversation->getTitle());
+
+        if (! $targetBag->exists($target)) {
+            return;
+        }
+
+        $targetBag->replace($target);
+        $this->bus->dispatch(new StoreTargetBag($targetBag));
+    }
+
+    #[AsEventListener(DocumentRenamed::class)]
+    public function renameOnDocumentRenamed(DocumentRenamed $event): void
+    {
+        $targetBag = $this->queryService->query(new GetTargetBag());
+        $target    = new LibraryDocumentTarget($event->document->getId(), $event->document->getTitle());
+
+        if (! $targetBag->exists($target)) {
+            return;
+        }
+
+        $targetBag->replace($target);
+        $this->bus->dispatch(new StoreTargetBag($targetBag));
+    }
+
+    #[AsEventListener(ImageRenamed::class)]
+    public function renameOnImageRenamed(ImageRenamed $event): void
+    {
+        $targetBag = $this->queryService->query(new GetTargetBag());
+        $target    = new LibraryImageTarget($event->image->getId(), $event->image->getTitle());
+
+        if (! $targetBag->exists($target)) {
+            return;
+        }
+
+        $targetBag->replace($target);
+        $this->bus->dispatch(new StoreTargetBag($targetBag));
+    }
+
+    #[AsEventListener(ItemRenamed::class)]
+    public function renameOnItemRename(ItemRenamed $event): void
+    {
+        $targetBag = $this->queryService->query(new GetTargetBag());
+        $target    = new WorldItemTarget($event->item->getId(), $event->item->getName());
+
+        if (! $targetBag->exists($target)) {
+            return;
+        }
+
+        $targetBag->replace($target);
+        $this->bus->dispatch(new StoreTargetBag($targetBag));
+    }
+}

--- a/src/Favorizer/Domain/TargetBag.php
+++ b/src/Favorizer/Domain/TargetBag.php
@@ -29,6 +29,12 @@ class TargetBag extends ArrayObject implements JsonSerializable
         return false;
     }
 
+    public function replace(Target $target): void
+    {
+        $this->remove($target);
+        $this->append($target);
+    }
+
     public function remove(Target $target): void
     {
         foreach ($this as $key => $checkTarget) {

--- a/src/World/Application/Command/StoreWorldItemHandler.php
+++ b/src/World/Application/Command/StoreWorldItemHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ChronicleKeeper\World\Application\Command;
 
 use ChronicleKeeper\Shared\Infrastructure\Database\DatabasePlatform;
+use ChronicleKeeper\Shared\Infrastructure\Messenger\MessageEventResult;
 use ChronicleKeeper\World\Domain\ValueObject\ConversationReference;
 use ChronicleKeeper\World\Domain\ValueObject\DocumentReference;
 use ChronicleKeeper\World\Domain\ValueObject\ImageReference;
@@ -18,7 +19,7 @@ class StoreWorldItemHandler
     {
     }
 
-    public function __invoke(StoreWorldItem $command): void
+    public function __invoke(StoreWorldItem $command): MessageEventResult
     {
         try {
             $this->platform->beginTransaction();
@@ -84,5 +85,7 @@ class StoreWorldItemHandler
 
             throw $e;
         }
+
+        return new MessageEventResult($command->item->flushEvents());
     }
 }

--- a/tests/Favorizer/Application/Event/TargetRenamingTest.php
+++ b/tests/Favorizer/Application/Event/TargetRenamingTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Favorizer\Application\Event;
+
+use ChronicleKeeper\Chat\Domain\Event\ConversationRenamed;
+use ChronicleKeeper\Document\Domain\Event\DocumentRenamed;
+use ChronicleKeeper\Favorizer\Application\Command\StoreTargetBag;
+use ChronicleKeeper\Favorizer\Application\Event\TargetRenaming;
+use ChronicleKeeper\Favorizer\Domain\TargetBag;
+use ChronicleKeeper\Favorizer\Domain\ValueObject\ChatConversationTarget;
+use ChronicleKeeper\Favorizer\Domain\ValueObject\LibraryDocumentTarget;
+use ChronicleKeeper\Favorizer\Domain\ValueObject\LibraryImageTarget;
+use ChronicleKeeper\Favorizer\Domain\ValueObject\WorldItemTarget;
+use ChronicleKeeper\Image\Domain\Event\ImageRenamed;
+use ChronicleKeeper\Shared\Application\Query\QueryService;
+use ChronicleKeeper\Test\Chat\Domain\Entity\ConversationBuilder;
+use ChronicleKeeper\Test\Document\Domain\Entity\DocumentBuilder;
+use ChronicleKeeper\Test\Image\Domain\Entity\ImageBuilder;
+use ChronicleKeeper\Test\World\Domain\Entity\ItemBuilder;
+use ChronicleKeeper\World\Domain\Event\ItemRenamed;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[CoversClass(TargetRenaming::class)]
+#[Small]
+class TargetRenamingTest extends TestCase
+{
+    private QueryService&MockObject $queryService;
+    private MessageBusInterface&MockObject $bus;
+    private TargetRenaming $targetRenaming;
+
+    protected function setUp(): void
+    {
+        $this->queryService   = $this->createMock(QueryService::class);
+        $this->bus            = $this->createMock(MessageBusInterface::class);
+        $this->targetRenaming = new TargetRenaming($this->queryService, $this->bus);
+    }
+
+    #[Test]
+    public function itRenamesConversation(): void
+    {
+        $conversation = (new ConversationBuilder())->build();
+        $event        = new ConversationRenamed($conversation, 'foo');
+
+        $targetBag = $this->createMock(TargetBag::class);
+        $targetBag->method('exists')->willReturn(true);
+
+        $this->queryService->method('query')->willReturn($targetBag);
+
+        $targetBag->expects($this->once())
+            ->method('replace')
+            ->with(new ChatConversationTarget($conversation->getId(), $conversation->getTitle()));
+
+        $this->bus->expects($this->once())
+            ->method('dispatch')
+            ->with(new StoreTargetBag($targetBag))
+            ->willReturn(new Envelope(new StoreTargetBag($targetBag)));
+
+        $this->targetRenaming->renameOnConversationRenamed($event);
+    }
+
+    #[Test]
+    public function itDoesNothingWhenConversationNotFound(): void
+    {
+        $conversation = (new ConversationBuilder())->build();
+        $event        = new ConversationRenamed($conversation, 'foo');
+
+        $targetBag = $this->createMock(TargetBag::class);
+        $targetBag->method('exists')->willReturn(false);
+
+        $this->queryService->method('query')->willReturn($targetBag);
+
+        $targetBag->expects($this->never())->method('replace');
+        $this->bus->expects($this->never())->method('dispatch');
+
+        $this->targetRenaming->renameOnConversationRenamed($event);
+    }
+
+    #[Test]
+    public function itRenamesDocument(): void
+    {
+        $document = (new DocumentBuilder())->build();
+        $event    = new DocumentRenamed($document, 'foo');
+
+        $targetBag = $this->createMock(TargetBag::class);
+        $targetBag->method('exists')->willReturn(true);
+
+        $this->queryService->method('query')->willReturn($targetBag);
+
+        $targetBag->expects($this->once())
+            ->method('replace')
+            ->with(new LibraryDocumentTarget($document->getId(), $document->getTitle()));
+
+        $this->bus->expects($this->once())
+            ->method('dispatch')
+            ->with(new StoreTargetBag($targetBag))
+            ->willReturn(new Envelope(new StoreTargetBag($targetBag)));
+
+        $this->targetRenaming->renameOnDocumentRenamed($event);
+    }
+
+    #[Test]
+    public function itDoesNothingWhenDocumentNotFound(): void
+    {
+        $document = (new DocumentBuilder())->build();
+        $event    = new DocumentRenamed($document, 'foo');
+
+        $targetBag = $this->createMock(TargetBag::class);
+        $targetBag->method('exists')->willReturn(false);
+
+        $this->queryService->method('query')->willReturn($targetBag);
+
+        $targetBag->expects($this->never())->method('replace');
+        $this->bus->expects($this->never())->method('dispatch');
+
+        $this->targetRenaming->renameOnDocumentRenamed($event);
+    }
+
+    #[Test]
+    public function itRenamesImage(): void
+    {
+        $image = (new ImageBuilder())->build();
+        $event = new ImageRenamed($image, 'foo');
+
+        $targetBag = $this->createMock(TargetBag::class);
+        $targetBag->method('exists')->willReturn(true);
+
+        $this->queryService->method('query')->willReturn($targetBag);
+
+        $targetBag->expects($this->once())
+            ->method('replace')
+            ->with(new LibraryImageTarget($image->getId(), $image->getTitle()));
+
+        $this->bus->expects($this->once())
+            ->method('dispatch')
+            ->with(new StoreTargetBag($targetBag))
+            ->willReturn(new Envelope(new StoreTargetBag($targetBag)));
+
+        $this->targetRenaming->renameOnImageRenamed($event);
+    }
+
+    #[Test]
+    public function itDoesNothingWhenImageNotFound(): void
+    {
+        $image = (new ImageBuilder())->build();
+        $event = new ImageRenamed($image, 'foo');
+
+        $targetBag = $this->createMock(TargetBag::class);
+        $targetBag->method('exists')->willReturn(false);
+
+        $this->queryService->method('query')->willReturn($targetBag);
+
+        $targetBag->expects($this->never())->method('replace');
+        $this->bus->expects($this->never())->method('dispatch');
+
+        $this->targetRenaming->renameOnImageRenamed($event);
+    }
+
+    #[Test]
+    public function itRenamesWorldItem(): void
+    {
+        $item  = (new ItemBuilder())->build();
+        $event = new ItemRenamed($item, 'foo');
+
+        $targetBag = $this->createMock(TargetBag::class);
+        $targetBag->method('exists')->willReturn(true);
+
+        $this->queryService->method('query')->willReturn($targetBag);
+
+        $targetBag->expects($this->once())
+            ->method('replace')
+            ->with(new WorldItemTarget($item->getId(), $item->getName()));
+
+        $this->bus->expects($this->once())
+            ->method('dispatch')
+            ->with(new StoreTargetBag($targetBag))
+            ->willReturn(new Envelope(new StoreTargetBag($targetBag)));
+
+        $this->targetRenaming->renameOnItemRename($event);
+    }
+
+    #[Test]
+    public function itDoesNothingWhenWorldItemNotFound(): void
+    {
+        $item  = (new ItemBuilder())->build();
+        $event = new ItemRenamed($item, 'foo');
+
+        $targetBag = $this->createMock(TargetBag::class);
+        $targetBag->method('exists')->willReturn(false);
+
+        $this->queryService->method('query')->willReturn($targetBag);
+
+        $targetBag->expects($this->never())->method('replace');
+        $this->bus->expects($this->never())->method('dispatch');
+
+        $this->targetRenaming->renameOnItemRename($event);
+    }
+}

--- a/tests/Favorizer/Domain/TargetBagTest.php
+++ b/tests/Favorizer/Domain/TargetBagTest.php
@@ -85,4 +85,45 @@ class TargetBagTest extends TestCase
             $targetBag->jsonSerialize(),
         );
     }
+
+    #[Test]
+    public function replaceExistingEntry(): void
+    {
+        $target = new ChatConversationTarget(
+            'f3ce2cce-888d-4812-8470-72cdd96faf4c',
+            'Chat Conversation',
+        );
+
+        $updatedTarget = new ChatConversationTarget(
+            'f3ce2cce-888d-4812-8470-72cdd96faf4c',
+            'Updated Chat Conversation',
+        );
+
+        $targetBag = new TargetBag($target);
+        $targetBag->replace($updatedTarget);
+
+        self::assertTrue($targetBag->exists($updatedTarget));
+        self::assertSame(
+            [$updatedTarget],
+            $targetBag->jsonSerialize(),
+        );
+    }
+
+    #[Test]
+    public function replaceNonExistingEntry(): void
+    {
+        $target = new ChatConversationTarget(
+            'f3ce2cce-888d-4812-8470-72cdd96faf4c',
+            'Chat Conversation',
+        );
+
+        $targetBag = new TargetBag();
+        $targetBag->replace($target);
+
+        self::assertTrue($targetBag->exists($target));
+        self::assertSame(
+            [$target],
+            $targetBag->jsonSerialize(),
+        );
+    }
 }


### PR DESCRIPTION
## Problem Statement

Currently when one has favorized something like a document or a world item the title is cached to the favorites. Sadly when renaming the favorized things the renaming events of those are not having any effect on the favorites.

## Solution

- Implement event listeners to the rename events of the aggregates that could be favorized
- Fix world items are not flushing events on storing