### PR TITLE
chore: Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "league/flysystem-ziparchive": "^3.28",
         "league/html-to-markdown": "^5.1",
         "oskarstark/readable-filesize-extension": "^1.2",
-        "php-llm/llm-chain": "^0.15",
+        "php-llm/llm-chain": "^0.16",
         "phpoffice/phpword": "^1.3",
         "smalot/pdfparser": "^2.11",
         "symfony/asset": "^7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1e90ecae98f3cb924a8eb0fa2eaa253",
+    "content-hash": "899883e40b43e36d33a856cb531f382a",
     "packages": [
         {
             "name": "composer/semver",
@@ -1077,16 +1077,16 @@
         },
         {
             "name": "php-llm/llm-chain",
-            "version": "0.15.2",
+            "version": "0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-llm/llm-chain.git",
-                "reference": "5da000ec0fb4fcc4d78399e40eac05506cfff6fc"
+                "reference": "374bf2a555456721018185f8d49aadc1f2a307a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-llm/llm-chain/zipball/5da000ec0fb4fcc4d78399e40eac05506cfff6fc",
-                "reference": "5da000ec0fb4fcc4d78399e40eac05506cfff6fc",
+                "url": "https://api.github.com/repos/php-llm/llm-chain/zipball/374bf2a555456721018185f8d49aadc1f2a307a5",
+                "reference": "374bf2a555456721018185f8d49aadc1f2a307a5",
                 "shasum": ""
             },
             "require": {
@@ -1151,9 +1151,9 @@
             "description": "A slim PHP component with tooling around LLMs.",
             "support": {
                 "issues": "https://github.com/php-llm/llm-chain/issues",
-                "source": "https://github.com/php-llm/llm-chain/tree/0.15.2"
+                "source": "https://github.com/php-llm/llm-chain/tree/0.16"
             },
-            "time": "2025-02-10T10:38:57+00:00"
+            "time": "2025-02-22T00:15:14+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -7696,16 +7696,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.5",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "451b17f9665481ee502adc39be987cb71067ece2"
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/451b17f9665481ee502adc39be987cb71067ece2",
-                "reference": "451b17f9665481ee502adc39be987cb71067ece2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
                 "shasum": ""
             },
             "require": {
@@ -7750,7 +7750,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-13T12:49:56+00:00"
+            "time": "2025-02-19T15:46:42+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -7975,16 +7975,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.0.2",
+            "version": "12.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "69dde560510151f7d04315fac6c72016cc5d7bc8"
+                "reference": "2e3038bff41d56114e5396151060f5ac9d2d6751"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/69dde560510151f7d04315fac6c72016cc5d7bc8",
-                "reference": "69dde560510151f7d04315fac6c72016cc5d7bc8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e3038bff41d56114e5396151060f5ac9d2d6751",
+                "reference": "2e3038bff41d56114e5396151060f5ac9d2d6751",
                 "shasum": ""
             },
             "require": {
@@ -8040,7 +8040,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.0.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.0.3"
             },
             "funding": [
                 {
@@ -8048,7 +8048,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-08T09:08:00+00:00"
+            "time": "2025-02-18T14:04:13+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -8297,16 +8297,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.0.2",
+            "version": "12.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6301fe5c1f5f34192ffd650a87fe055677a32212"
+                "reference": "e469daf4e173c4b7f2d6154d364f468f3713f632"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6301fe5c1f5f34192ffd650a87fe055677a32212",
-                "reference": "6301fe5c1f5f34192ffd650a87fe055677a32212",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e469daf4e173c4b7f2d6154d364f468f3713f632",
+                "reference": "e469daf4e173c4b7f2d6154d364f468f3713f632",
                 "shasum": ""
             },
             "require": {
@@ -8316,11 +8316,11 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.0",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.0.2",
+                "phpunit/php-code-coverage": "^12.0.3",
                 "phpunit/php-file-iterator": "^6.0.0",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
@@ -8374,7 +8374,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.0.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.0.4"
             },
             "funding": [
                 {
@@ -8390,7 +8390,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-08T09:18:47+00:00"
+            "time": "2025-02-21T06:10:40+00:00"
         },
         {
             "name": "rector/rector",


### PR DESCRIPTION
```
  - Downloading phpstan/phpstan (2.1.6)
  - Downloading phpunit/php-code-coverage (12.0.3)
  - Downloading phpunit/phpunit (12.0.4)
  - Removing symfony/polyfill-php81 (v1.31.0)
  - Removing sebastian/code-unit-reverse-lookup (4.0.1)
  - Removing sebastian/code-unit (3.0.2)
  - Upgrading twig/twig (v3.19.0 => v3.20.0): Extracting archive
  - Upgrading phpdocumentor/reflection-docblock (5.5.1 => 5.6.1): Extracting archive
  - Upgrading php-llm/llm-chain (0.15.1 => 0.15.2): Extracting archive
  - Upgrading phpstan/phpstan (2.1.2 => 2.1.6): Extracting archive
  - Upgrading sebastian/version (5.0.2 => 6.0.0): Extracting archive
  - Upgrading sebastian/type (5.1.0 => 6.0.0): Extracting archive
  - Upgrading sebastian/recursion-context (6.0.2 => 7.0.0): Extracting archive
  - Upgrading sebastian/object-reflector (4.0.1 => 5.0.0): Extracting archive
  - Upgrading sebastian/object-enumerator (6.0.1 => 7.0.0): Extracting archive
  - Upgrading sebastian/global-state (7.0.2 => 8.0.0): Extracting archive
  - Upgrading sebastian/exporter (6.3.0 => 7.0.0): Extracting archive
  - Upgrading sebastian/environment (7.2.0 => 8.0.0): Extracting archive
  - Upgrading sebastian/diff (6.0.2 => 7.0.0): Extracting archive
  - Upgrading sebastian/comparator (6.3.0 => 7.0.0): Extracting archive
  - Upgrading sebastian/cli-parser (3.0.2 => 4.0.0): Extracting archive
  - Upgrading phpunit/php-timer (7.0.1 => 8.0.0): Extracting archive
  - Upgrading phpunit/php-text-template (4.0.1 => 5.0.0): Extracting archive
  - Upgrading phpunit/php-invoker (5.0.1 => 6.0.0): Extracting archive
  - Upgrading phpunit/php-file-iterator (5.1.0 => 6.0.0): Extracting archive
  - Upgrading sebastian/lines-of-code (3.0.1 => 4.0.0): Extracting archive
  - Upgrading sebastian/complexity (4.0.1 => 5.0.0): Extracting archive
  - Upgrading phpunit/php-code-coverage (11.0.8 => 12.0.3): Extracting archive
  - Upgrading myclabs/deep-copy (1.12.1 => 1.13.0): Extracting archive
  - Upgrading phpunit/phpunit (11.5.6 => 12.0.4): Extracting archive
  - Upgrading rector/rector (2.0.8 => 2.0.9): Extracting archive
  - Upgrading spaze/phpstan-disallowed-calls (v4.2.1 => v4.3.1): Extracting archive
  - Upgrading symfony/ux-autocomplete (v2.22.1 => v2.23.0): Extracting archive
  - Upgrading symfony/ux-icons (v2.22.1 => v2.23.0): Extracting archive
  - Upgrading symfony/ux-twig-component (v2.22.1 => v2.23.0): Extracting archive
  - Upgrading symfony/stimulus-bundle (v2.22.1 => v2.23.0): Extracting archive
  - Upgrading symfony/ux-live-component (v2.22.1 => v2.23.0): Extracting archive
  - Upgrading symfony/ux-turbo (v2.22.1 => v2.23.0): Extracting archive
  - Upgrading twig/extra-bundle (v3.19.0 => v3.20.0): Extracting archive
  - Upgrading twig/markdown-extra (v3.19.0 => v3.20.0): Extracting archive
  - Upgrading php-llm/llm-chain (0.15.2 => 0.16): Extracting archive
  ```