### PR TITLE
feat(docker): Improve docker production

### DIFF
--- a/.docker/frankenphp/Caddyfile
+++ b/.docker/frankenphp/Caddyfile
@@ -1,0 +1,43 @@
+{
+	{$CADDY_GLOBAL_OPTIONS}
+
+	frankenphp {
+		{$FRANKENPHP_CONFIG}
+	}
+}
+
+{$CADDY_EXTRA_CONFIG}
+
+{$SERVER_NAME:localhost} {
+    # Import auth configuration if it exists
+    import /etc/caddy/auth.conf
+
+    log {
+		{$CADDY_SERVER_LOG_OPTIONS}
+		# Redact the authorization query parameter that can be set by Mercure
+		format filter {
+			request>uri query {
+				replace authorization REDACTED
+			}
+		}
+	}
+	root /app/public
+	encode zstd br gzip
+
+	{$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+	# Disable Topics tracking if not enabled explicitly: https://github.com/jkarlin/topics
+	header ?Permissions-Policy "browsing-topics=()"
+
+	@phpRoute {
+		not file {path}
+	}
+	rewrite @phpRoute index.php
+
+	@frontController path index.php
+	php @frontController
+
+	file_server {
+		hide *.php
+	}
+}

--- a/.docker/frankenphp/Dockerfile
+++ b/.docker/frankenphp/Dockerfile
@@ -5,6 +5,10 @@ FROM frankenphp_upstream AS chronicle_keeper_base
 WORKDIR /app
 VOLUME /app/var/
 
+RUN apt-get update && \
+    apt-get install -y apache2-utils && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN install-php-extensions \
     @composer \
 	gd \
@@ -21,6 +25,8 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 
 ENV PHP_INI_SCAN_DIR=":$PHP_INI_DIR/app.conf.d"
 COPY --link ./.docker/frankenphp/conf.d/app.ini $PHP_INI_DIR/app.conf.d/
+COPY --link ./.docker/frankenphp/Caddyfile /etc/caddy/Caddyfile
+COPY --link --chmod=755 .docker/frankenphp/auth-config.sh /usr/local/bin/auth-config
 COPY --link --chmod=755 ./.docker/frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 
 ENTRYPOINT ["docker-entrypoint"]
@@ -37,9 +43,10 @@ CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--watch" ]
 FROM chronicle_keeper_base AS chronicle_keeper_prod
 
 ENV APP_ENV=prod
-ENV FRANKENPHP_CONFIG="import worker.Caddyfile"
+ENV FRANKENPHP_CONFIG=""
+ENV BASIC_AUTH_USER=""
+ENV BASIC_AUTH_PASSWORD=""
 
-COPY --link ./.docker/frankenphp/worker.Caddyfile /etc/caddy/worker.Caddyfile
 COPY --link composer.* symfony.* ./
 RUN set -eux; \
 	composer install --no-cache --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress

--- a/.docker/frankenphp/Dockerfile
+++ b/.docker/frankenphp/Dockerfile
@@ -1,15 +1,56 @@
-FROM dunglas/frankenphp
+FROM dunglas/frankenphp:1-php8.4 AS frankenphp_upstream
+
+FROM frankenphp_upstream AS chronicle_keeper_base
+
+WORKDIR /app
+VOLUME /app/var/
 
 RUN install-php-extensions \
+    @composer \
 	gd \
 	intl \
     mbstring \
 	zip \
 	opcache \
     pdo \
-    pdo_pgsql;
+    pdo_pgsql \
+;
+
+# https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
 ENV PHP_INI_SCAN_DIR=":$PHP_INI_DIR/app.conf.d"
-
-WORKDIR /app
 COPY --link ./.docker/frankenphp/conf.d/app.ini $PHP_INI_DIR/app.conf.d/
+COPY --link --chmod=755 ./.docker/frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+
+ENTRYPOINT ["docker-entrypoint"]
+
+HEALTHCHECK --start-period=60s CMD curl -f http://localhost:2019/metrics || exit 1
+CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile" ]
+
+FROM chronicle_keeper_base AS chronicle_keeper_dev
+
+ENV APP_ENV=dev
+
+CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--watch" ]
+
+FROM chronicle_keeper_base AS chronicle_keeper_prod
+
+ENV APP_ENV=prod
+ENV FRANKENPHP_CONFIG="import worker.Caddyfile"
+
+COPY --link ./.docker/frankenphp/worker.Caddyfile /etc/caddy/worker.Caddyfile
+COPY --link composer.* symfony.* ./
+RUN set -eux; \
+	composer install --no-cache --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
+
+COPY --link . ./
+RUN rm -Rf ./docker/frankenphp
+
+RUN set -eux; \
+	mkdir -p var/cache var/log; \
+	composer dump-autoload --classmap-authoritative --no-dev; \
+	composer dump-env prod; \
+	composer run-script --no-dev post-install-cmd; \
+	chmod +x bin/console; \
+    sync;

--- a/.docker/frankenphp/Dockerfile
+++ b/.docker/frankenphp/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1-php8.4 AS frankenphp_upstream
+FROM dunglas/frankenphp:1.4.4-php8.4 AS frankenphp_upstream
 
 FROM frankenphp_upstream AS chronicle_keeper_base
 
@@ -50,7 +50,7 @@ RUN rm -Rf ./docker/frankenphp
 RUN set -eux; \
 	mkdir -p var/cache var/log; \
 	composer dump-autoload --classmap-authoritative --no-dev; \
-	composer dump-env prod; \
 	composer run-script --no-dev post-install-cmd; \
 	chmod +x bin/console; \
+    php bin/console asset-map:compile; \
     sync;

--- a/.docker/frankenphp/Dockerfile
+++ b/.docker/frankenphp/Dockerfile
@@ -5,10 +5,6 @@ FROM frankenphp_upstream AS chronicle_keeper_base
 WORKDIR /app
 VOLUME /app/var/
 
-RUN apt-get update && \
-    apt-get install -y apache2-utils && \
-    rm -rf /var/lib/apt/lists/*
-
 RUN install-php-extensions \
     @composer \
 	gd \

--- a/.docker/frankenphp/auth-config.sh
+++ b/.docker/frankenphp/auth-config.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Only configure auth if both username and password are provided
+if [ -n "$BASIC_AUTH_USER" ] && [ -n "$BASIC_AUTH_PASSWORD" ]; then
+    # Create Caddy auth snippet
+    cat > /etc/caddy/auth.conf << EOF
+    @auth {
+        not path /health* /metrics*
+        expression {env.APP_ENV} == 'prod'
+    }
+    handle @auth {
+        basic_auth {
+            ${BASIC_AUTH_USER} ${BASIC_AUTH_PASSWORD}
+        }
+    }
+EOF
+fi

--- a/.docker/frankenphp/auth-config.sh
+++ b/.docker/frankenphp/auth-config.sh
@@ -15,4 +15,7 @@ if [ -n "$BASIC_AUTH_USER" ] && [ -n "$BASIC_AUTH_PASSWORD" ]; then
         }
     }
 EOF
+else
+    # Create empty file when no credentials are provided
+    : > /etc/caddy/auth.conf
 fi

--- a/.docker/frankenphp/docker-entrypoint.sh
+++ b/.docker/frankenphp/docker-entrypoint.sh
@@ -3,6 +3,11 @@ set -e
 
 if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 
+    # Configure authentication if in prod mode
+    if [ "$APP_ENV" = "prod" ]; then
+        auth-config
+    fi
+
     php bin/console -V
 
 fi

--- a/.docker/frankenphp/docker-entrypoint.sh
+++ b/.docker/frankenphp/docker-entrypoint.sh
@@ -4,7 +4,6 @@ set -e
 if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 
     php bin/console -V
-    php bin/console asset-map:compile
 
 fi
 

--- a/.docker/frankenphp/docker-entrypoint.sh
+++ b/.docker/frankenphp/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
+
+    php bin/console -V
+    php bin/console asset-map:compile
+
+fi
+
+exec docker-php-entrypoint "$@"

--- a/.docker/frankenphp/worker.Caddyfile
+++ b/.docker/frankenphp/worker.Caddyfile
@@ -1,4 +1,0 @@
-worker {
-	file ./public/index.php
-	env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
-}

--- a/.docker/frankenphp/worker.Caddyfile
+++ b/.docker/frankenphp/worker.Caddyfile
@@ -1,0 +1,4 @@
+worker {
+	file ./public/index.php
+	env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,64 @@
+# Version control
+.git/
+.gitattributes
+.gitignore
+.github/
+
+# Development environments
+.idea/
+.vscode/
+.editorconfig
+
+# Temporary project files
+var/settings.json
+var/system_prompts.json
+var/tmp/*
+
+# Test and coverage
+.phpunit.cache/
+.phpcs-cache
+coverage/
+coverage.xml
+tests/
+phpunit.xml
+.phpbench/
+phpstan.neon
+phpcs.xml.dist
+
+# Environment files (except dist)
+.env.*
+!.env.dist
+
+# Docker
+.docker/*/Dockerfile
+docker-compose*.yml
+compose*.yaml
+!compose.yaml
+!compose.prod.yaml
+
+# Cache and logs
+var/cache/*
+var/log/*
+
+# Dependencies
+vendor/
+assets/vendor/
+
+# Documentation and non-essential files
+CHANGELOG.md
+CONTRIBUTING.md
+README.md
+LICENSE
+
+# Development tools configuration
+.makefile/
+
+# Database
+*.sqlite
+*.sqlite3
+
+# Temporary files
+*.cache
+*.log
+.DS_Store
+Thumbs.db

--- a/.makefile/Makefile.docker
+++ b/.makefile/Makefile.docker
@@ -1,0 +1,16 @@
+SHELL := /bin/bash
+.PHONY: *
+
+docker-build:
+ifeq ($(APP_ENV),prod)
+	docker compose -f compose.yaml -f compose.prod.yaml build
+else
+	docker compose --profile=dev build
+endif
+
+docker-up:
+ifeq ($(APP_ENV),prod)
+	docker compose -f compose.yaml -f compose.prod.yaml up --wait
+else
+	docker compose --profile=dev up --wait
+endif

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,0 +1,8 @@
+services:
+  php:
+    build:
+      context: .
+      target: chronicle_keeper_dev
+    volumes:
+      - ./:/app
+    tty: true

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,7 @@
+services:
+  php:
+    build:
+      context: .
+      target: chronicle_keeper_prod
+    environment:
+      APP_SECRET: ${APP_SECRET}

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -5,3 +5,5 @@ services:
       target: chronicle_keeper_prod
     environment:
       APP_SECRET: ${APP_SECRET}
+      BASIC_AUTH_USER: ${BASIC_AUTH_USER:-}
+      BASIC_AUTH_PASSWORD: ${BASIC_AUTH_PASSWORD:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,19 +1,19 @@
 services:
   php:
-    image: dunglas/frankenphp
+    image: ${IMAGES_PREFIX:-}app-php
+    restart: unless-stopped
     build:
       context: .
       dockerfile: .docker/frankenphp/Dockerfile
-    restart: always
+    environment:
+      SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
     ports:
-      - "80:80" # HTTP
-      - "443:443" # HTTPS
-      - "443:443/udp" # HTTP/3
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
     volumes:
-      - ./:/app
       - caddy_data:/data
       - caddy_config:/config
-    tty: true
 
   database:
     profiles: ["dev", "all"]

--- a/src/Settings/Application/Service/Exporter.php
+++ b/src/Settings/Application/Service/Exporter.php
@@ -7,10 +7,21 @@ namespace ChronicleKeeper\Settings\Application\Service;
 use ChronicleKeeper\Settings\Application\Service\Exporter\ExportSettings;
 use ChronicleKeeper\Settings\Application\Service\Exporter\SingleExport;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use ZipArchive;
 
 use function date;
+use function fclose;
+use function feof;
+use function file_exists;
+use function fopen;
+use function fread;
+use function fwrite;
+use function is_resource;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
 
 class Exporter
 {
@@ -38,5 +49,70 @@ class Exporter
         $zip->close();
 
         return $zipName;
+    }
+
+    /** @param resource $stream The stream to write to */
+    public function exportToStream($stream): void
+    {
+        if (! is_resource($stream)) {
+            throw new RuntimeException('Invalid stream provided');
+        }
+
+        $tempFile = $this->createTemporaryFile();
+
+        try {
+            // Use existing export logic to create the ZIP
+            $this->export($tempFile);
+            $this->streamFileContents($tempFile, $stream);
+        } finally {
+            // Ensure temporary file is removed even if an exception occurs
+            if (file_exists($tempFile)) {
+                @unlink($tempFile);
+            }
+        }
+    }
+
+    private function createTemporaryFile(): string
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'export_');
+        if ($tempFile === false) {
+            throw new RuntimeException('Failed to create temporary file');
+        }
+
+        return $tempFile;
+    }
+
+    /** @param resource $targetStream */
+    private function streamFileContents(string $sourceFile, $targetStream): void
+    {
+        $handle = fopen($sourceFile, 'rb');
+        if ($handle === false) {
+            throw new RuntimeException('Failed to open export file for reading');
+        }
+
+        try {
+            $this->transferData($handle, $targetStream);
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @param resource $source Source stream
+     * @param resource $target Target stream
+     */
+    private function transferData($source, $target): void
+    {
+        while (! feof($source)) {
+            $data = fread($source, 8192);
+            if ($data === false) {
+                throw new RuntimeException('Failed to read from export file');
+            }
+
+            $result = fwrite($target, $data);
+            if ($result === false) {
+                throw new RuntimeException('Failed to write to output stream');
+            }
+        }
     }
 }

--- a/src/Settings/Application/Service/Importer.php
+++ b/src/Settings/Application/Service/Importer.php
@@ -41,8 +41,8 @@ class Importer
          * So the version 0.6 is required version to import from. This will also stop newer versions from being
          * imported.
          */
-        if (! version_compare($versionOfArchive, '0.7', 'eq')) {
-            throw new RuntimeException('Only import from version 0.7 is allowed for this version.');
+        if (! version_compare($versionOfArchive, '0.7', '>=')) {
+            throw new RuntimeException('Only import from version 0.7 and higher is allowed for this version.');
         }
 
         if ($importSettings->pruneLibrary === true) {

--- a/src/Settings/Application/Service/Version.php
+++ b/src/Settings/Application/Service/Version.php
@@ -12,10 +12,10 @@ use function end;
 use function explode;
 use function preg_match_all;
 
-final readonly class Version
+class Version
 {
     public function __construct(
-        private FileAccess $fileAccess,
+        private readonly FileAccess $fileAccess,
     ) {
     }
 

--- a/src/Shared/Presentation/Command/ExportCommand.php
+++ b/src/Shared/Presentation/Command/ExportCommand.php
@@ -12,9 +12,13 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
 
 use function file_exists;
+use function is_string;
 use function unlink;
+
+use const STDOUT;
 
 #[AsCommand(
     name: 'app:export',
@@ -28,7 +32,7 @@ final class ExportCommand extends Command
         parent::__construct();
     }
 
-    public function configure(): void
+    protected function configure(): void
     {
         $this->addArgument(
             'filename',
@@ -42,25 +46,84 @@ final class ExportCommand extends Command
             InputOption::VALUE_NONE,
             'Force the export, an existing file will be deleted.',
         );
+
+        $this->addOption(
+            'stream',
+            's',
+            InputOption::VALUE_NONE,
+            'Stream the ZIP file to STDOUT instead of saving to disk',
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
+        $io       = new SymfonyStyle($input, $output);
+        $isStream = (bool) $input->getOption('stream');
+
+        try {
+            if ($isStream) {
+                return $this->handleStreamExport();
+            }
+
+            return $this->handleFileExport($input, $io);
+        } catch (Throwable $e) {
+            if (! $isStream) {
+                $io->error('Export failed: ' . $e->getMessage());
+            }
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * Handles exporting to a file
+     */
+    private function handleFileExport(InputInterface $input, SymfonyStyle $io): int
+    {
         $io->title('Exporting ZIP Archive');
 
         $filename = $input->getArgument('filename');
-        if (file_exists($filename) && $input->getOption('force') === false) {
-            $io->error('File already exists, use --force to overwrite.');
+        if (! is_string($filename)) {
+            $io->error('Filename must be provided when not using stream mode.');
 
             return self::FAILURE;
         }
 
-        @unlink($filename);
-        $zipName = $this->exporter->export($filename);
+        if (! $this->validateFilename($filename, (bool) $input->getOption('force'), $io)) {
+            return self::FAILURE;
+        }
 
+        $zipName = $this->exporter->export($filename);
         $io->success('Exported ZIP Archive: ' . $zipName);
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Handles exporting to STDOUT stream
+     */
+    private function handleStreamExport(): int
+    {
+        $this->exporter->exportToStream(STDOUT);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Validates if the file can be written to
+     */
+    private function validateFilename(string $filename, bool $force, SymfonyStyle $io): bool
+    {
+        if (file_exists($filename) && ! $force) {
+            $io->error('File already exists, use --force to overwrite.');
+
+            return false;
+        }
+
+        if (file_exists($filename)) {
+            @unlink($filename);
+        }
+
+        return true;
     }
 }

--- a/tests/Document/Infrastructure/Serializer/DocumentDenormalizerTest.php
+++ b/tests/Document/Infrastructure/Serializer/DocumentDenormalizerTest.php
@@ -125,7 +125,7 @@ class DocumentDenormalizerTest extends TestCase
             )
             ->willReturn($directory = (new DirectoryBuilder())->build());
 
-        $documentDenormalizer = (new DocumentDenormalizer($queryService));
+        $documentDenormalizer = new DocumentDenormalizer($queryService);
         $documentDenormalizer->setDenormalizer($denormalizer);
 
         $document = $documentDenormalizer->denormalize($array, Document::class);
@@ -162,7 +162,7 @@ class DocumentDenormalizerTest extends TestCase
             )
             ->willReturn($directory = (new DirectoryBuilder())->build());
 
-        $documentDenormalizer = (new DocumentDenormalizer($queryService));
+        $documentDenormalizer = new DocumentDenormalizer($queryService);
         $documentDenormalizer->setDenormalizer($denormalizer);
 
         $document       = $documentDenormalizer->denormalize($array, Document::class);

--- a/tests/Shared/Presentation/Command/ExportCommandTest.php
+++ b/tests/Shared/Presentation/Command/ExportCommandTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Shared\Presentation\Command;
+
+use ChronicleKeeper\Settings\Application\Service\Exporter;
+use ChronicleKeeper\Shared\Presentation\Command\ExportCommand;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+use const STDOUT;
+
+#[CoversClass(ExportCommand::class)]
+#[Small]
+final class ExportCommandTest extends TestCase
+{
+    private MockObject&Exporter $exporter;
+    private CommandTester $commandTester;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->exporter = $this->createMock(Exporter::class);
+        $command        = new ExportCommand($this->exporter);
+
+        $application = new Application();
+        $application->add($command);
+        $command = $application->find('app:export');
+
+        $this->commandTester = new CommandTester($command);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($this->exporter, $this->commandTester);
+    }
+
+    #[Test]
+    public function itShouldExportToSpecifiedFile(): void
+    {
+        $outputFile = tempnam(sys_get_temp_dir(), 'export_test_');
+        @unlink($outputFile); // Remove the file so we can test creation
+
+        // Set up expectation
+        $this->exporter->expects($this->once())
+            ->method('export')
+            ->with($outputFile)
+            ->willReturn($outputFile);
+
+        // Execute the command
+        $this->commandTester->execute(['filename' => $outputFile]);
+
+        // Assert command output
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Exporting ZIP Archive', $output);
+        self::assertStringContainsString('Exported ZIP Archive:', $output);
+
+        // Assert command status code
+        self::assertSame(0, $this->commandTester->getStatusCode());
+    }
+
+    #[Test]
+    public function itShouldFailWhenFileExistsWithoutForceOption(): void
+    {
+        // Create a file that already exists
+        $existingFile = tempnam(sys_get_temp_dir(), 'export_existing_');
+
+        try {
+            // Exporter should not be called
+            $this->exporter->expects($this->never())->method('export');
+
+            // Execute the command without force option
+            $this->commandTester->execute(['filename' => $existingFile]);
+
+            // Assert command output
+            $output = $this->commandTester->getDisplay();
+            self::assertStringContainsString('Exporting ZIP Archive', $output);
+            self::assertStringContainsString('File already exists, use --force to overwrite.', $output);
+
+            // Assert command status code
+            self::assertSame(1, $this->commandTester->getStatusCode());
+        } finally {
+            // Clean up
+            @unlink($existingFile);
+        }
+    }
+
+    #[Test]
+    public function itShouldOverwriteExistingFileWithForceOption(): void
+    {
+        // Create a file that already exists
+        $existingFile = tempnam(sys_get_temp_dir(), 'export_force_');
+
+        try {
+            // Set up expectation
+            $this->exporter->expects($this->once())
+                ->method('export')
+                ->with($existingFile)
+                ->willReturn($existingFile);
+
+            // Execute the command with force option
+            $this->commandTester->execute([
+                'filename' => $existingFile,
+                '--force' => true,
+            ]);
+
+            // Assert command output
+            $output = $this->commandTester->getDisplay();
+            self::assertStringContainsString('Exporting ZIP Archive', $output);
+            self::assertStringContainsString('Exported ZIP Archive:', $output);
+
+            // Assert command status code
+            self::assertSame(0, $this->commandTester->getStatusCode());
+        } finally {
+            // Clean up
+            @unlink($existingFile);
+        }
+    }
+
+    #[Test]
+    public function itShouldFailWhenNoFilenameProvidedWithoutStream(): void
+    {
+        // Exporter should not be called
+        $this->exporter->expects($this->never())->method('export');
+        $this->exporter->expects($this->never())->method('exportToStream');
+
+        // Execute the command without filename and without stream option
+        $this->commandTester->execute([]);
+
+        // Assert command output
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Exporting ZIP Archive', $output);
+        self::assertStringContainsString('Filename must be provided when not using stream mode.', $output);
+
+        // Assert command status code
+        self::assertSame(1, $this->commandTester->getStatusCode());
+    }
+
+    #[Test]
+    public function itShouldExportToStreamWhenStreamOptionProvided(): void
+    {
+        // Set up expectation for stream export
+        $this->exporter->expects($this->once())
+            ->method('exportToStream')
+            ->with(STDOUT);
+
+        // Execute the command with stream option
+        $this->commandTester->execute(['--stream' => true]);
+
+        // With stream output, we shouldn't see normal console output
+        $output = $this->commandTester->getDisplay();
+        self::assertEmpty($output);
+
+        // Assert command status code
+        self::assertSame(0, $this->commandTester->getStatusCode());
+    }
+
+    #[Test]
+    public function itShouldHandleExporterExceptions(): void
+    {
+        $outputFile = tempnam(sys_get_temp_dir(), 'export_error_');
+        @unlink($outputFile); // Remove the file so we can test creation
+
+        // Set up expectation for exception
+        $this->exporter->expects($this->once())
+            ->method('export')
+            ->with($outputFile)
+            ->willThrowException(new RuntimeException('Export process failed'));
+
+        // Execute the command
+        $this->commandTester->execute(['filename' => $outputFile]);
+
+        // Assert command output
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Exporting ZIP Archive', $output);
+        self::assertStringContainsString('Export failed: Export process failed', $output);
+
+        // Assert command status code
+        self::assertSame(1, $this->commandTester->getStatusCode());
+    }
+}

--- a/tests/Shared/Presentation/Command/ImportCommandTest.php
+++ b/tests/Shared/Presentation/Command/ImportCommandTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Shared\Presentation\Command;
+
+use ChronicleKeeper\Settings\Application\Service\Importer;
+use ChronicleKeeper\Settings\Application\Service\ImportSettings;
+use ChronicleKeeper\Shared\Presentation\Command\ImportCommand;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function file_put_contents;
+use function strtolower;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+#[CoversClass(ImportCommand::class)]
+#[Small]
+final class ImportCommandTest extends TestCase
+{
+    private MockObject&Importer $importer;
+    private CommandTester $commandTester;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importer = $this->createMock(Importer::class);
+        $command        = new ImportCommand($this->importer);
+
+        $application = new Application();
+        $application->add($command);
+        $command = $application->find('app:import');
+
+        $this->commandTester = new CommandTester($command);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($this->importer, $this->commandTester);
+    }
+
+    #[Test]
+    public function itShouldImportArchiveFromFile(): void
+    {
+        // Create a test archive file
+        $archiveFile = tempnam(sys_get_temp_dir(), 'test_archive_');
+        file_put_contents($archiveFile, 'test archive content');
+
+        // Set up expectations
+        $this->importer->expects($this->once())
+            ->method('import')
+            ->with(
+                $archiveFile,
+                self::callback(static fn (ImportSettings $settings) => $settings->overwriteSettings === false
+                    && $settings->overwriteLibrary === false
+                    && $settings->pruneLibrary === false
+                    && $settings->removeArchive === false),
+            );
+
+        // Execute the command
+        $this->commandTester->execute(['archive' => $archiveFile]);
+
+        // Assert command output
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Importing ZIP Archive', $output);
+        self::assertStringContainsString('Importing application from:', $output);
+        self::assertStringContainsString('ZIP Archive was imported successfully.', $output);
+
+        // Assert command status code
+        self::assertSame(0, $this->commandTester->getStatusCode());
+
+        // Clean up
+        @unlink($archiveFile);
+    }
+
+    #[Test]
+    public function itShouldImportArchiveWithAllOptionsEnabled(): void
+    {
+        // Create a test archive file
+        $archiveFile = tempnam(sys_get_temp_dir(), 'test_archive_');
+        file_put_contents($archiveFile, 'test archive content');
+
+        // Set up expectations
+        $this->importer->expects($this->once())
+            ->method('import')
+            ->with(
+                $archiveFile,
+                self::callback(static fn (ImportSettings $settings) => $settings->overwriteSettings === true
+                    && $settings->overwriteLibrary === true
+                    && $settings->pruneLibrary === true
+                    && $settings->removeArchive === false),
+            );
+
+        // Execute the command
+        $this->commandTester->execute([
+            'archive' => $archiveFile,
+            '--overwrite_settings' => true,
+            '--overwrite_library' => true,
+            '--prune_library' => true,
+        ]);
+
+        // Assert command output
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Importing ZIP Archive', $output);
+        self::assertStringContainsString('ZIP Archive was imported successfully.', $output);
+
+        // Assert command status code
+        self::assertSame(0, $this->commandTester->getStatusCode());
+
+        // Clean up
+        @unlink($archiveFile);
+    }
+
+    #[Test]
+    public function itShouldFailWhenFileDoesNotExist(): void
+    {
+        // Execute the command with non-existent file
+        $this->commandTester->execute(['archive' => '/path/to/nonexistent/file.zip']);
+
+        // Assert command output
+        $output = $this->commandTester->getDisplay(true);
+
+        self::assertStringContainsString('Importing ZIP Archive', $output);
+        self::assertStringContainsString('error', strtolower($output));
+        self::assertStringContainsString('/path/to/nonexistent/file.zip', $output);
+
+        // Assert command status code
+        self::assertSame(1, $this->commandTester->getStatusCode());
+    }
+
+    #[Test]
+    public function itShouldFailWhenNoFileProvidedWithoutStream(): void
+    {
+        // Execute the command without a file
+        $this->commandTester->execute([]);
+
+        // Assert command output
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Importing ZIP Archive', $output);
+        self::assertStringContainsString('Archive path must be provided when not using stream mode.', $output);
+
+        // Assert command status code
+        self::assertSame(1, $this->commandTester->getStatusCode());
+    }
+
+    #[Test]
+    public function itShouldHandleImporterExceptions(): void
+    {
+        // Create a test archive file
+        $archiveFile = tempnam(sys_get_temp_dir(), 'test_archive_');
+        file_put_contents($archiveFile, 'test archive content');
+
+        // Set up expectations for failure
+        $this->importer->expects($this->once())
+            ->method('import')
+            ->willThrowException(new RuntimeException('Import process failed'));
+
+        // Execute the command
+        $this->commandTester->execute(['archive' => $archiveFile]);
+
+        // Assert command output
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Importing ZIP Archive', $output);
+        self::assertStringContainsString('Import failed: Import process failed', $output);
+
+        // Assert command status code
+        self::assertSame(1, $this->commandTester->getStatusCode());
+
+        // Clean up
+        @unlink($archiveFile);
+    }
+}


### PR DESCRIPTION
As some people requested an online available instance of the application here are some improvements to make it runnable better in an server environment. The docker container production environment got some improvements and additionally basic auth is now possible to block external access as mostly it should not be public available without any other security available. 

For handling updates in such an online environment the export and import commands have been improved to work with streams to handle export outside of the running docker container. For example to backup and re-import after update, etc.