### PR TITLE
feature(Calendar): Implement Moon Cycle Offset

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ includes:
 
 parameters:
     level: 8
+    phpVersion: 80300
     paths:
         - public/index.php
         - src

--- a/src/Calendar/Application/Service/CalendarFactory.php
+++ b/src/Calendar/Application/Service/CalendarFactory.php
@@ -26,7 +26,7 @@ final class CalendarFactory
         $weekDaysData = $this->transformWeekDaysData($settings->getWeeks());
 
         // Create moon cycle
-        $moonCycle = new MoonCycle($settings->getMoonCycleDays());
+        $moonCycle = new MoonCycle($settings->getMoonCycleDays(), $settings->getMoonCycleOffset());
 
         // Create configuration
         $configuration = $this->createConfiguration();

--- a/src/Calendar/Domain/Entity/Calendar/MoonCycle.php
+++ b/src/Calendar/Domain/Entity/Calendar/MoonCycle.php
@@ -15,8 +15,10 @@ class MoonCycle
 {
     public function __construct(
         private readonly float $daysOfACycle,
+        private readonly float $moonCycleOffset = 0,
     ) {
         Assert::greaterThan($daysOfACycle, 0, 'The moon cycle should have a days value.');
+        Assert::greaterThanEq($moonCycleOffset, 0, 'The moon cycle should have a days value.');
     }
 
     public function getMoonCycle(): float
@@ -24,11 +26,17 @@ class MoonCycle
         return $this->daysOfACycle;
     }
 
+    public function getMoonCycleOffset(): float
+    {
+        return $this->moonCycleOffset;
+    }
+
     public function getDaysOfACycle(CalendarDate $date): float
     {
-        $totalDays = $date->getTotalDaysFromCalendarStart();
+        $totalDays    = $date->getTotalDaysFromCalendarStart();
+        $adjustedDays = $totalDays + $this->moonCycleOffset;
 
-        return fmod($totalDays, $this->daysOfACycle);
+        return fmod($adjustedDays, $this->daysOfACycle);
     }
 
     public function getMoonStateOfDay(CalendarDate $date): MoonState

--- a/src/Settings/Presentation/Controller/CalendarOverview/GeneralSettings.php
+++ b/src/Settings/Presentation/Controller/CalendarOverview/GeneralSettings.php
@@ -24,12 +24,15 @@ final class GeneralSettings extends AbstractController
         $settings            = $this->settingsHandler->get();
         $calendarSettings    = $settings->getCalendarSettings();
         $allCalendarSettings = $calendarSettings->toArray();
+        $moonsSettings       = $allCalendarSettings['moons'];
 
         $form     = $this->createForm(
             GeneralType::class,
             $data = [
-                'moonCycleDays' => $allCalendarSettings['moon_cycle_days'] ?? 30,
-                'current_day'   => $allCalendarSettings['current_day'] ?? null,
+                'moonName' => $moonsSettings[0]['moon_name'] ?? 'Mond',
+                'moonCycleDays' => $moonsSettings[0]['moon_cycle_days'] ?? 30,
+                'moonCycleOffset' => $moonsSettings[0]['moon_cycle_offset'] ?? 0,
+                'current_day' => $allCalendarSettings['current_day'] ?? null,
             ],
         );
 
@@ -39,8 +42,15 @@ final class GeneralSettings extends AbstractController
             $data = $form->getData();
 
             // Overwrite Settings
-            $allCalendarSettings['moon_cycle_days'] = $data['moonCycleDays'];
-            $allCalendarSettings['current_day']     = $data['current_day'];
+            $allCalendarSettings['moons'] = [
+                [
+                    'moon_name' => $data['moonName'],
+                    'moon_cycle_days' => $data['moonCycleDays'],
+                    'moon_cycle_offset' => $data['moonCycleOffset'],
+                ],
+            ];
+
+            $allCalendarSettings['current_day'] = $data['current_day'];
 
             $settings->setCalendarSettings(CalendarSettings::fromArray($allCalendarSettings));
 

--- a/src/Settings/Presentation/Form/Calendar/GeneralType.php
+++ b/src/Settings/Presentation/Form/Calendar/GeneralType.php
@@ -6,8 +6,11 @@ namespace ChronicleKeeper\Settings\Presentation\Form\Calendar;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 
 final class GeneralType extends AbstractType
@@ -18,11 +21,33 @@ final class GeneralType extends AbstractType
         $builder->add('current_day', CurrentDayType::class);
 
         $builder->add(
+            'moonName',
+            TextType::class,
+            [
+                'label' => 'Name des Mondes',
+                'empty_data' => 'Moon',
+                'constraints' => [new NotBlank()],
+            ],
+        );
+
+        $builder->add(
             'moonCycleDays',
             IntegerType::class,
             [
                 'label' => 'Mondzyklus in Tagen',
                 'constraints' => [new NotNull(), new GreaterThanOrEqual(1)],
+            ],
+        );
+
+        $builder->add(
+            'moonCycleOffset',
+            NumberType::class,
+            [
+                'label' => 'Offset des Mondzyklus in Tagen',
+                'help' => 'Anpassung des Mondzyklus um einige Tage, eine Gleitkommazahl ist erlaubt.',
+                'empty_data' => 0.0,
+                'html5' => true,
+                'constraints' => [new NotNull(), new GreaterThanOrEqual(0)],
             ],
         );
     }

--- a/src/Settings/Presentation/Form/Calendar/GeneralType.php
+++ b/src/Settings/Presentation/Form/Calendar/GeneralType.php
@@ -44,7 +44,7 @@ final class GeneralType extends AbstractType
             NumberType::class,
             [
                 'label' => 'Offset des Mondzyklus in Tagen',
-                'help' => 'Anpassung des Mondzyklus um einige Tage, eine Gleitkommazahl ist erlaubt.',
+                'help' => 'Verschiebt den Mond um x.y Tage vorwärts im Zyklus für den gesamten Kalender.',
                 'empty_data' => 0.0,
                 'html5' => true,
                 'constraints' => [new NotNull(), new GreaterThanOrEqual(0)],

--- a/templates/settings/calendar_overview/general_settings.html.twig
+++ b/templates/settings/calendar_overview/general_settings.html.twig
@@ -26,7 +26,9 @@
                         </div>
                     </div>
 
+                    {{ form_row(form.moonName) }}
                     {{ form_row(form.moonCycleDays) }}
+                    {{ form_row(form.moonCycleOffset) }}
 
                 </div>
             </div>

--- a/templates/settings/calendar_settings.html.twig
+++ b/templates/settings/calendar_settings.html.twig
@@ -68,8 +68,16 @@
                                             <td>{{ currentDay is empty ? 'Keine Einstellung vorhanden (Standard: 0-1-1)' : currentDay.year ~ '-' ~ currentDay.month ~ '-' ~ currentDay.day }}</td>
                                         </tr>
                                         <tr>
+                                            <td>Name des Mondes</td>
+                                            <td>{{ calendar_settings.moonName }}</td>
+                                        </tr>
+                                        <tr>
                                             <td>Mondzyklus</td>
                                             <td>{{ calendar_settings.moonCycleDays }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Offset des Mondzyklus</td>
+                                            <td>{{ calendar_settings.moonCycleOffset }}</td>
                                         </tr>
                                     </tbody>
                                 </table>

--- a/tests/Calendar/Domain/Entity/Calendar/MoonCycleTest.php
+++ b/tests/Calendar/Domain/Entity/Calendar/MoonCycleTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 final class MoonCycleTest extends TestCase
 {
     #[Test]
-    public function itIsNotConstructableWithMooNCycleLowerThenOne(): void
+    public function itIsNotConstructableWithMoonCycleLowerThenOne(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The moon cycle should have a days value.');
@@ -31,11 +31,21 @@ final class MoonCycleTest extends TestCase
     }
 
     #[Test]
-    public function itIsConstructableWithMooNCycleGreaterThenOne(): void
+    public function itIsNotConstructableWithMoonCycleOffsetLowerThenZero(): void
     {
-        $moonCycle = new MoonCycle(29);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The moon cycle should have a days value.');
+
+        new MoonCycle(1, -1);
+    }
+
+    #[Test]
+    public function itIsConstructableWithValidValues(): void
+    {
+        $moonCycle = new MoonCycle(29, 12);
 
         self::assertSame(29.0, $moonCycle->getMoonCycle());
+        self::assertSame(12.0, $moonCycle->getMoonCycleOffset());
     }
 
     #[Test]
@@ -107,6 +117,13 @@ final class MoonCycleTest extends TestCase
         yield 'Day 36: First Quarter' => [
             new CalendarDate($calendar, 0, 2, 6),
             MoonState::FIRST_QUARTER,
+        ];
+
+        $calendar = ExampleCalendars::getLinearWithLeapDays(14);
+
+        yield 'Offset Moon - Day 1: Full Moon' => [
+            new CalendarDate($calendar, 0, 1, 1),
+            MoonState::FULL_MOON,
         ];
     }
 }

--- a/tests/Calendar/Domain/Entity/Fixture/DefaultCalendarSettingsBuilder.php
+++ b/tests/Calendar/Domain/Entity/Fixture/DefaultCalendarSettingsBuilder.php
@@ -21,15 +21,20 @@ abstract class DefaultCalendarSettingsBuilder
     /** @var array<WeekSettings> */
     protected array $weeks = [];
 
-    protected float $moonCycleDays = 30;
-    protected bool $isFinished     = true;
+    protected string $moonName       = 'Moon';
+    protected float $moonCycleDays   = 30;
+    protected float $moonCycleOffset = 0;
+
+    protected bool $isFinished = true;
 
     protected CurrentDay|null $currentDay = null;
 
     public function build(): CalendarSettings
     {
         return new CalendarSettings(
+            $this->moonName,
             $this->moonCycleDays,
+            $this->moonCycleOffset,
             $this->isFinished,
             $this->months,
             $this->epochs,

--- a/tests/Calendar/Domain/Entity/Fixture/ExampleCalendars.php
+++ b/tests/Calendar/Domain/Entity/Fixture/ExampleCalendars.php
@@ -29,7 +29,7 @@ class ExampleCalendars
         );
     }
 
-    public static function getOnlyRegularDays(): Calendar
+    public static function getOnlyRegularDays(float $moonCycleOffset = 0): Calendar
     {
         return new Calendar(
             new Configuration(beginsInYear: 0),
@@ -59,11 +59,11 @@ class ExampleCalendars
                 ['index' => 6, 'name' => 'Saturday'],
                 ['index' => 7, 'name' => 'Sunday'],
             ],
-            new MoonCycle(29.5),
+            new MoonCycle(29.5, $moonCycleOffset),
         );
     }
 
-    public static function getLinearWithLeapDays(): Calendar
+    public static function getLinearWithLeapDays(float $moonCycleOffset = 0): Calendar
     {
         return new Calendar(
             new Configuration(beginsInYear: 0),
@@ -160,7 +160,7 @@ class ExampleCalendars
                 ['index' => 9, 'name' => 'Ninthday'],
                 ['index' => 10, 'name' => 'Tenthday'],
             ],
-            new MoonCycle(30),
+            new MoonCycle(30, $moonCycleOffset),
         );
     }
 

--- a/tests/Settings/Domain/ValueObject/Settings/CalendarSettingsTest.php
+++ b/tests/Settings/Domain/ValueObject/Settings/CalendarSettingsTest.php
@@ -124,10 +124,51 @@ final class CalendarSettingsTest extends TestCase
                     'name' => 'Monday',
                 ],
             ],
+
         ];
 
         $settings = CalendarSettings::fromArray($data);
         self::assertNull($settings->getCurrentDay());
+    }
+
+    #[Test]
+    public function itConstructsFromArrayWithoutMoons(): void
+    {
+        $data = [
+            'moons' => [],
+            'is_finished' => true,
+            'months' => [
+                [
+                    'index' => 1,
+                    'name' => 'January',
+                    'days' => 31,
+                ],
+            ],
+            'epochs' => [
+                [
+                    'name' => 'First Age',
+                    'start_year' => 1,
+                    'end_year' => 100,
+                ],
+            ],
+            'weeks' => [
+                [
+                    'index' => 1,
+                    'name' => 'Monday',
+                ],
+            ],
+            'current_day' => [
+                'year' => 1262,
+                'month' => 1,
+                'day' => 21,
+            ],
+        ];
+
+        $settings = CalendarSettings::fromArray($data);
+
+        self::assertSame('Mond', $settings->getMoonName());
+        self::assertSame(30.0, $settings->getMoonCycleDays());
+        self::assertSame(0.0, $settings->getMoonCycleOffset());
     }
 
     #[Test]

--- a/tests/Settings/Domain/ValueObject/Settings/CalendarSettingsTest.php
+++ b/tests/Settings/Domain/ValueObject/Settings/CalendarSettingsTest.php
@@ -32,7 +32,13 @@ final class CalendarSettingsTest extends TestCase
     public function itConstructsFromArray(): void
     {
         $data = [
-            'moon_cycle_days' => 301,
+            'moons' => [
+                [
+                    'moon_name' => 'Moon',
+                    'moon_cycle_days' => 35,
+                    'moon_cycle_offset' => 10.2,
+                ],
+            ],
             'is_finished' => true,
             'months' => [
                 [
@@ -74,7 +80,9 @@ final class CalendarSettingsTest extends TestCase
         self::assertCount(1, $settings->getEpochs());
         self::assertCount(1, $settings->getWeeks());
 
-        self::assertSame(301.0, $settings->getMoonCycleDays());
+        self::assertSame('Moon', $settings->getMoonName());
+        self::assertSame(35.0, $settings->getMoonCycleDays());
+        self::assertSame(10.2, $settings->getMoonCycleOffset());
         self::assertTrue($settings->isFinished());
 
         $currentDay = $settings->getCurrentDay();
@@ -88,7 +96,13 @@ final class CalendarSettingsTest extends TestCase
     public function itConstructsFromArrayWithoutCurrentDay(): void
     {
         $data = [
-            'moon_cycle_days' => 301,
+            'moons' => [
+                [
+                    'moon_name' => 'Moon',
+                    'moon_cycle_days' => 35,
+                    'moon_cycle_offset' => 10.2,
+                ],
+            ],
             'is_finished' => true,
             'months' => [
                 [
@@ -125,10 +139,25 @@ final class CalendarSettingsTest extends TestCase
         $week       = new WeekSettings(1, 'Monday');
         $currentDay = new CurrentDay(1262, 1, 21);
 
-        $settings = new CalendarSettings(301.0, true, [$month], [$epoch], [$week], $currentDay);
+        $settings = new CalendarSettings(
+            'Moon',
+            301.0,
+            10.2,
+            true,
+            [$month],
+            [$epoch],
+            [$week],
+            $currentDay,
+        );
 
         $expected = [
-            'moon_cycle_days' => 301.0,
+            'moons' => [
+                [
+                    'moon_name' => 'Moon',
+                    'moon_cycle_days' => 301.0,
+                    'moon_cycle_offset' => 10.2,
+                ],
+            ],
             'is_finished' => true,
             'months' => [
                 [
@@ -175,10 +204,24 @@ final class CalendarSettingsTest extends TestCase
         $epoch   = new EpochSettings('First Age', 1, 100);
         $week    = new WeekSettings(1, 'Monday');
 
-        $settings = new CalendarSettings(301.0, true, [$month], [$epoch], [$week]);
+        $settings = new CalendarSettings(
+            'Moon',
+            301.0,
+            10.2,
+            true,
+            [$month],
+            [$epoch],
+            [$week],
+        );
 
         $expected = [
-            'moon_cycle_days' => 301.0,
+            'moons' => [
+                [
+                    'moon_name' => 'Moon',
+                    'moon_cycle_days' => 301.0,
+                    'moon_cycle_offset' => 10.2,
+                ],
+            ],
             'is_finished' => true,
             'months' => [
                 [
@@ -222,10 +265,25 @@ final class CalendarSettingsTest extends TestCase
         $week       = new WeekSettings(1, 'Monday');
         $currentDay = new CurrentDay(1262, 1, 21);
 
-        $settings = new CalendarSettings(35, false, [$month], [$epoch], [$week], $currentDay);
+        $settings = new CalendarSettings(
+            'Moon',
+            35,
+            10.2,
+            false,
+            [$month],
+            [$epoch],
+            [$week],
+            $currentDay,
+        );
 
         $expected = [
-            'moon_cycle_days' => 35,
+            'moons' => [
+                [
+                    'moon_name' => 'Moon',
+                    'moon_cycle_days' => 35,
+                    'moon_cycle_offset' => 10.2,
+                ],
+            ],
             'is_finished' => false,
             'months' => [
                 [

--- a/tests/Settings/Domain/ValueObject/SettingsBuilder.php
+++ b/tests/Settings/Domain/ValueObject/SettingsBuilder.php
@@ -76,7 +76,9 @@ class SettingsBuilder
         $week    = new WeekSettings(1, 'First Day');
 
         $this->calendarSettings = new CalendarSettings(
+            'Mond',
             30,
+            0.0,
             true,
             [$month],
             [$epoch],

--- a/tests/Settings/Presentation/Controller/CalendarOverview/GeneralSettingsTest.php
+++ b/tests/Settings/Presentation/Controller/CalendarOverview/GeneralSettingsTest.php
@@ -51,7 +51,9 @@ final class GeneralSettingsTest extends WebTestCase
         self::assertFormValue('form[name="general"]', 'general[current_day][year]', '1');
         self::assertFormValue('form[name="general"]', 'general[current_day][month]', '1');
         self::assertFormValue('form[name="general"]', 'general[current_day][day]', '1');
+        self::assertFormValue('form[name="general"]', 'general[moonName]', 'Mond');
         self::assertFormValue('form[name="general"]', 'general[moonCycleDays]', '30');
+        self::assertFormValue('form[name="general"]', 'general[moonCycleOffset]', '0');
     }
 
     #[Test]
@@ -68,7 +70,9 @@ final class GeneralSettingsTest extends WebTestCase
                     'month' => 3,
                     'day' => 4,
                 ],
+                'moonName' => 'My Moon',
                 'moonCycleDays' => 12,
+                'moonCycleOffset' => 2.5,
             ],
         ]);
 
@@ -80,7 +84,9 @@ final class GeneralSettingsTest extends WebTestCase
         self::assertSame(12, $calendarSettings->getCurrentDay()?->getYear());
         self::assertSame(3, $calendarSettings->getCurrentDay()->getMonth());
         self::assertSame(4, $calendarSettings->getCurrentDay()->getDay());
+        self::assertSame('My Moon', $calendarSettings->getMoonName());
         self::assertSame(12.0, $calendarSettings->getMoonCycleDays());
+        self::assertSame(2.5, $calendarSettings->getMoonCycleOffset());
     }
 
     #[Test]
@@ -93,7 +99,9 @@ final class GeneralSettingsTest extends WebTestCase
                     'month' => 24,
                     'day' => 16,
                 ],
+                'moonName' => 'My Moon',
                 'moonCycleDays' => 12,
+                'moonCycleOffset' => 2.5,
             ],
         ]);
 


### PR DESCRIPTION
This feature allows to configure a moon cycle offset to move the moon state a few days foward which enables the calendar to start with a different moon state then "New Moon". So if one wants to have a calendar starting with an full moon this brings the possibility and is so taken into account from the beginning of the calendar on. 