### PR TITLE
[Settings] fix: llm tool configuration template

### DIFF
--- a/templates/settings/chatbot_functions.html.twig
+++ b/templates/settings/chatbot_functions.html.twig
@@ -48,7 +48,7 @@
                             </div>
 
                             <div class="accordion" id="accordion-example">
-                                {% for tool in tools.map %}
+                                {% for tool in tools.tools %}
                                     <div class="accordion-item">
                                         <button class="accordion-header {{ loop.first ? '' : 'collapsed' }}" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ loop.index }}" aria-expanded="true">
                                             <div class="accordion-header-text"><h4>{{ tool.name }}</h4></div>

--- a/tests/Settings/Presentation/Controller/ChangeSettings/ChangeChatbotFunctionsTest.php
+++ b/tests/Settings/Presentation/Controller/ChangeSettings/ChangeChatbotFunctionsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChronicleKeeper\Test\Settings\Presentation\Controller\ChangeSettings;
+
+use ChronicleKeeper\Settings\Presentation\Controller\ChangeSettings\ChangeChatbotFunctions;
+use ChronicleKeeper\Test\WebTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Request;
+
+#[CoversClass(ChangeChatbotFunctions::class)]
+#[Large]
+class ChangeChatbotFunctionsTest extends WebTestCase
+{
+    #[Test]
+    public function itIsShowingTheForm(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/settings/chatbot_functions');
+
+        self::assertResponseIsSuccessful();
+
+        $content = (string) $this->client->getResponse()->getContent();
+
+        self::assertStringContainsString('calendar_date_calculator', $content);
+        self::assertStringContainsString('library_documents', $content);
+        self::assertStringContainsString('library_images', $content);
+        self::assertStringContainsString('world_items', $content);
+    }
+}


### PR DESCRIPTION
The LLM Package upgrade had changed the toolbox method from `getMap` to `getTools`. This was not reflected in the view. So i added a test because nothing failed there.