### PR TITLE
[Docker] Upgrade frankenphp to latest version

### DIFF
--- a/.docker/frankenphp/Dockerfile
+++ b/.docker/frankenphp/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1.4.4-php8.4 AS frankenphp_upstream
+FROM dunglas/frankenphp:1.9.0-php8.4 AS frankenphp_upstream
 
 FROM frankenphp_upstream AS chronicle_keeper_base
 


### PR DESCRIPTION
This PR updates the base Docker image for FrankenPHP from `1.4.4-php8.4` to `1.9.0-php8.4` in `.docker/frankenphp/Dockerfile`.