### PR TITLE
[Environment] streamline environment configuration

### DIFF
--- a/.docker/frankenphp/Dockerfile
+++ b/.docker/frankenphp/Dockerfile
@@ -6,14 +6,14 @@ WORKDIR /app
 # VOLUME /app/var/
 
 RUN install-php-extensions \
-    @composer \
+	@composer \
 	gd \
 	intl \
-    mbstring \
+	mbstring \
 	zip \
 	opcache \
-    pdo \
-    pdo_pgsql \
+	pdo \
+	pdo_pgsql \
 ;
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
@@ -32,15 +32,14 @@ CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile" ]
 
 FROM chronicle_keeper_base AS chronicle_keeper_dev
 
-ENV APP_ENV=dev
-
+# APP_ENV will be inherited from .env or can be overridden via environment variables
 CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--watch" ]
 
 FROM chronicle_keeper_base AS chronicle_keeper_prod
 
 COPY --link ./.docker/frankenphp/conf.d/app.prod.ini $PHP_INI_DIR/app.conf.d/
 
-ENV APP_ENV=prod
+# APP_ENV will be inherited from .env or can be overridden via environment variables
 ENV FRANKENPHP_CONFIG=""
 ENV BASIC_AUTH_USER=""
 ENV BASIC_AUTH_PASSWORD=""
@@ -57,7 +56,7 @@ RUN set -eux; \
 	composer dump-autoload --classmap-authoritative --no-dev; \
 	composer run-script --no-dev post-install-cmd; \
 	chmod +x bin/console; \
-    php bin/console asset-map:compile; \
-    php bin/console cache:clear; \
-    php bin/console cache:warmup; \
-    sync;
+	php bin/console asset-map:compile; \
+	php bin/console cache:clear; \
+	php bin/console cache:warmup; \
+	sync;

--- a/.dockerignore
+++ b/.dockerignore
@@ -26,7 +26,12 @@ phpstan.neon
 phpcs.xml.dist
 
 # Environment files (except dist)
-.env.*
+.env.local
+.env.*.local
+.env.prod.local
+.env.test.local
+!.env
+!.env.test
 !.env.dist
 
 # Docker

--- a/.env
+++ b/.env
@@ -1,7 +1,5 @@
-APP_DEBUG=1
 APP_ENV=dev
-
-DATABASE_TYPE=PgSql
-DATABASE_URL=pgsql://app:app@database:5432/chronicle-keeper?serverVersion=15&charset=utf8
-
+APP_DEBUG=1
 APP_SECRET=ChangeMeInProdThisIsJustAPlaceholder123456
+
+DATABASE_URL=pgsql://app:app@database:5432/chronicle-keeper?serverVersion=15&charset=utf8

--- a/.env.dist
+++ b/.env.dist
@@ -1,7 +1,0 @@
-# Base application configuration
-APP_DEBUG=0
-APP_ENV=prod
-APP_SECRET=
-
-# Database configuration placeholder
-DATABASE_URL=

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,6 @@
+APP_DEBUG=0
+APP_ENV=test
+
+DATABASE_URL=pgsql://app:app@database_test:5432/chronicle-keeper?serverVersion=15&charset=utf8
+
+APP_SECRET=ThisIsTheTestSecretForTestEnvironment123456

--- a/.env.test.dist
+++ b/.env.test.dist
@@ -1,7 +1,0 @@
-APP_DEBUG=0
-APP_ENV=test
-
-DATABASE_TYPE=PgSql
-DATABASE_URL=pgsql://app:app@database_test:5434/chronicle-keeper?serverVersion=15&charset=utf8
-
-APP_SECRET=ThisIsTheTestSecretForTestEnvironment123456

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           php-version: '8.3'
 
-      - name: Setup Temporary Config
-        run: cp .env.test.dist .env.test
-
       - uses: "ramsey/composer-install@v3"
 
       - name: Linting PHP
@@ -52,9 +49,6 @@ jobs:
         - uses: shivammathur/setup-php@v2
           with:
             php-version: ${{ matrix.php }}
-
-        - name: Setup Temporary Config
-          run: cp .env.test.dist .env.test
 
         - uses: "ramsey/composer-install@v3"
 
@@ -111,7 +105,6 @@ jobs:
 
       - name: Setup Database Config
         run: |
-          cp .env.test.dist .env.test
           echo "DATABASE_URL=pgsql://app:app@localhost:5432/chronicle-keeper?serverVersion=15&charset=utf8" >> .env.test
 
       - uses: "ramsey/composer-install@v3"

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,10 @@
 /vendor/
 /public/assets/
 
-.env
-.env.test
 .env.local
 .env.*.local
-!.env.dist
+.env.prod.local
+.env.test.local
 
 /.phpcs-cache
 /.phpunit.cache/

--- a/.makefile/Makefile.setup-env
+++ b/.makefile/Makefile.setup-env
@@ -2,23 +2,7 @@ SHELL := /bin/bash
 .PHONY: *
 
 # Environment handling
-setup-env = @if [ ! -f .env.$(1).dist ]; then \
-		echo "Error: .env.$(1).dist not found"; \
-		exit 1; \
-	fi; \
-	cp .env.$(1).dist .env;
-
-setup-test-env = @if [ ! -f .env.$(1).dist ]; then \
-		echo "Error: .env.$(1).dist not found"; \
-		exit 1; \
-	fi; \
-	cp .env.$(1).dist .env.test;
-
-setup-dev-env: ## Setup development environment
-	$(call setup-env,dev)
-
-setup-test-env: ## Setup test environment
-	$(call setup-test-env,test)
+# (Removed custom env setup logic; rely on Symfony's .env loading)
 
 setup-database: ## setup the database
 	 $(PHP) bin/console app:db:init --force -vvv

--- a/.makefile/Makefile.test
+++ b/.makefile/Makefile.test
@@ -10,11 +10,11 @@ check-test-containers:
 		sleep 3; \
 	fi
 
-test: setup-test-env ## Run tests with configured database
+test: ## Run tests with configured database
 	$(MAKE) check-test-containers
 	$(PHP) bin/console cache:clear --env=test
 	$(PHP) bin/console app:db:drop -f --env=test
 	docker compose exec -e APP_ENV=test php vendor/bin/phpunit --colors
 
-coverage: setup-test-env ## Generate test coverage report
+coverage: ## Generate test coverage report
 	XDEBUG_MODE=coverage $(PHP) vendor/bin/phpunit --coverage-html=coverage --coverage-clover=coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ help: ## Show this help
 	@awk -F ':.*?## ' '/^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 # Development commands
-dev: setup-dev-env ## Start development environment
+dev: ## Start development environment
 	docker compose --profile dev up -d
 
-make dev-stop: ## Stop development environment
+dev-stop: ## Stop development environment
 	docker compose --profile dev down
 
 reset: ## Reset the environment and deletes the linked containers

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,9 +7,6 @@ services:
       dockerfile: .docker/frankenphp/Dockerfile
     environment:
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
-      DATABASE_TYPE: PgSql
-      DATABASE_CONNECTION: pgsql:host=${POSTGRES_HOST:-database};port=${POSTGRES_PORT:-5432};dbname=${POSTGRES_DB:-chronicle-keeper};user=${POSTGRES_USER:-app};password=${POSTGRES_PASSWORD:-app}
-      DATABASE_URL: pgsql://${POSTGRES_USER:-${POSTGRES_PASSWORD:-app}}:app@${POSTGRES_HOST:-database}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-chronicle-keeper}?serverVersion=15&charset=utf8
     ports:
       # HTTP
       - target: 80
@@ -49,11 +46,11 @@ services:
       dockerfile: .docker/postgres/Dockerfile
     restart: always
     environment:
-      POSTGRES_USER: app_test
-      POSTGRES_PASSWORD: app_test
-      POSTGRES_DB: chronicle-keeper-test
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: chronicle-keeper
     ports:
-      - "5433:5432"
+      - "5434:5432"
     volumes:
       - postgres_test_data:/var/lib/postgresql/data
 

--- a/composer.lock
+++ b/composer.lock
@@ -250,16 +250,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "5fe09532be619202d59c70956c6fb20e97933ee3"
+                "reference": "ac336c95ea9e13433d56ca81c308b39db0e1a2a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/5fe09532be619202d59c70956c6fb20e97933ee3",
-                "reference": "5fe09532be619202d59c70956c6fb20e97933ee3",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/ac336c95ea9e13433d56ca81c308b39db0e1a2a7",
+                "reference": "ac336c95ea9e13433d56ca81c308b39db0e1a2a7",
                 "shasum": ""
             },
             "require": {
@@ -336,7 +336,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/4.3.0"
+                "source": "https://github.com/doctrine/dbal/tree/4.3.1"
             },
             "funding": [
                 {
@@ -352,7 +352,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-16T19:31:04+00:00"
+            "time": "2025-07-22T10:09:51+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -1095,16 +1095,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405"
+                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
-                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/10732241927d3971d28e7ea7b5712721fa2296ca",
+                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca",
                 "shasum": ""
             },
             "require": {
@@ -1133,7 +1133,7 @@
                 "symfony/process": "^5.4 | ^6.0 | ^7.0",
                 "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
-                "vimeo/psalm": "^4.24.0 || ^5.0.0"
+                "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
             "suggest": {
                 "symfony/yaml": "v2.3+ required if using the Front Matter extension"
@@ -1198,7 +1198,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-05T12:20:28+00:00"
+            "time": "2025-07-20T12:47:49+00:00"
         },
         {
             "name": "league/config",
@@ -8071,16 +8071,16 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.1",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
-                "reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
@@ -8163,7 +8163,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-06-27T17:24:01+00:00"
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -8299,16 +8299,16 @@
         },
         {
             "name": "masterminds/html5",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6"
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
-                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
                 "shasum": ""
             },
             "require": {
@@ -8360,9 +8360,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
             },
-            "time": "2024-03-31T07:05:07+00:00"
+            "time": "2025-07-25T09:04:22+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -8751,16 +8751,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.18",
+            "version": "2.1.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7"
+                "reference": "473a8c30e450d87099f76313edcbb90852f9afdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee1f390b7a70cdf74a2b737e554f68afea885db7",
-                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/473a8c30e450d87099f76313edcbb90852f9afdf",
+                "reference": "473a8c30e450d87099f76313edcbb90852f9afdf",
                 "shasum": ""
             },
             "require": {
@@ -8805,25 +8805,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-17T17:22:31+00:00"
+            "time": "2025-07-21T19:58:24+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.6",
+            "version": "2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "6b92469f8a7995e626da3aa487099617b8dfa260"
+                "reference": "9a9b161baee88a5f5c58d816943cff354ff233dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6b92469f8a7995e626da3aa487099617b8dfa260",
-                "reference": "6b92469f8a7995e626da3aa487099617b8dfa260",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/9a9b161baee88a5f5c58d816943cff354ff233dc",
+                "reference": "9a9b161baee88a5f5c58d816943cff354ff233dc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0.4"
+                "phpstan/phpstan": "^2.1.18"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
@@ -8856,22 +8856,22 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.6"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.7"
             },
-            "time": "2025-03-26T12:47:06+00:00"
+            "time": "2025-07-13T11:31:46+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.4",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "3e139cbe67fafa3588e1dbe27ca50f31fdb6236a"
+                "reference": "f9f77efa9de31992a832ff77ea52eb42d675b094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/3e139cbe67fafa3588e1dbe27ca50f31fdb6236a",
-                "reference": "3e139cbe67fafa3588e1dbe27ca50f31fdb6236a",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/f9f77efa9de31992a832ff77ea52eb42d675b094",
+                "reference": "f9f77efa9de31992a832ff77ea52eb42d675b094",
                 "shasum": ""
             },
             "require": {
@@ -8904,22 +8904,22 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.4"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.6"
             },
-            "time": "2025-03-18T11:42:40+00:00"
+            "time": "2025-07-21T12:19:29+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "2.0.6",
+            "version": "2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "5005288e07583546ea00b52de4a9ac412eb869d7"
+                "reference": "392f7ab8f52a0a776977be4e62535358c28e1b15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/5005288e07583546ea00b52de4a9ac412eb869d7",
-                "reference": "5005288e07583546ea00b52de4a9ac412eb869d7",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/392f7ab8f52a0a776977be4e62535358c28e1b15",
+                "reference": "392f7ab8f52a0a776977be4e62535358c28e1b15",
                 "shasum": ""
             },
             "require": {
@@ -8975,9 +8975,9 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.6"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.7"
             },
-            "time": "2025-05-14T07:00:05+00:00"
+            "time": "2025-07-22T09:40:57+00:00"
         },
         {
             "name": "phpstan/phpstan-webmozart-assert",
@@ -9471,21 +9471,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "d0917c069bb0d9bb06ed111cf052510f609015a4"
+                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/d0917c069bb0d9bb06ed111cf052510f609015a4",
-                "reference": "d0917c069bb0d9bb06ed111cf052510f609015a4",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40a71441dd73fa150a66102f5ca1364c44fc8fff",
+                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.17"
+                "phpstan/phpstan": "^2.1.18"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -9519,7 +9519,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.1.1"
+                "source": "https://github.com/rectorphp/rector/tree/2.1.2"
             },
             "funding": [
                 {
@@ -9527,7 +9527,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-10T11:31:31+00:00"
+            "time": "2025-07-17T19:30:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
## Streamlined Environment Configuration & Improved Test Safety

This PR refactors the environment setup for ChronicleKeeper, making it simpler and more robust for both development and CI workflows. Environment files are now standardized, reducing manual steps and potential confusion. Docker and Makefile logic have been cleaned up to rely on Symfony's conventions, and redundant configuration has been removed.

A critical bug was fixed: running tests no longer risks deleting the development database, ensuring safer test execution and better isolation between environments.

**Highlights:**
- Unified `.env` and `.env.test` usage for easier onboarding and CI integration
- Docker and Makefile improvements for cleaner environment handling
- Test database configuration corrected and isolated from development
- Removal of legacy and redundant environment setup scripts
- All changes follow doctrine coding standards and are compatible with PHPStan Level 8

Developers should update local scripts and remove obsolete `.env` files to benefit from the new workflow. Standard commands for development, testing, and code quality remain